### PR TITLE
Wire event flags into environment, add save state loading

### DIFF
--- a/pokemon_red_ai/environment/gym_env.py
+++ b/pokemon_red_ai/environment/gym_env.py
@@ -42,7 +42,8 @@ class PokemonRedGymEnv(gym.Env):
                  reward_strategy: str = "exploration",
                  reward_config: Optional[RewardConfig] = None,
                  screen_size: Tuple[int, int] = (80, 72),
-                 observation_type: str = "multi_modal"):
+                 observation_type: str = "multi_modal",
+                 save_state_path: Optional[str] = None):
         """
         Initialize Pokemon Red Gymnasium environment.
 
@@ -54,6 +55,9 @@ class PokemonRedGymEnv(gym.Env):
             reward_config: Custom reward configuration
             screen_size: Target screen size (width, height)
             observation_type: Type of observation ('multi_modal', 'minimal', 'screen_only')
+            save_state_path: Optional path to a PyBoy ``.state`` file.
+                If provided, ``reset()`` loads this state instead of
+                replaying the intro sequence (much faster).
         """
         super().__init__()
 
@@ -62,6 +66,7 @@ class PokemonRedGymEnv(gym.Env):
         self.max_episode_steps = max_episode_steps
         self.screen_size = screen_size
         self.observation_type = observation_type
+        self.save_state_path = save_state_path
 
         # Initialize game game
         self.game = PokemonRedAgent(
@@ -93,9 +98,10 @@ class PokemonRedGymEnv(gym.Env):
             config=reward_config
         )
 
-        # Define action space (8 Game Boy buttons)
-        self.action_space = gym.spaces.Discrete(8)
-        self.action_names = ['A', 'B', 'SELECT', 'START', 'RIGHT', 'LEFT', 'UP', 'DOWN']
+        # Define action space (7 useful Game Boy buttons — SELECT removed
+        # per analysis_plan.md §5.2; it has no effect in Pokemon Red)
+        self.action_space = gym.spaces.Discrete(7)
+        self.action_names = ['A', 'B', 'START', 'RIGHT', 'LEFT', 'UP', 'DOWN']
 
         # Define observation space based on type
         if observation_type == "multi_modal":
@@ -261,8 +267,15 @@ class PokemonRedGymEnv(gym.Env):
 
             # Performance metrics
             'total_episodes': self.total_episodes,
-            'successful_resets': self.successful_resets
+            'successful_resets': self.successful_resets,
+
+            # Event flag progress (when using EventProgressRewardCalculator)
+            'battle_state': game_state.get('battle_state', 0),
         }
+
+        # Add event flag progress if the reward calculator supports it
+        if hasattr(self.reward_calculator, 'get_event_progress'):
+            info['event_progress'] = self.reward_calculator.get_event_progress()
 
         return info
 
@@ -339,10 +352,27 @@ class PokemonRedGymEnv(gym.Env):
         # Reset reward calculator
         self.reward_calculator.reset()
 
-        # Reset game using the proven working method
+        # Determine save state: options override, then instance default
+        save_state = None
+        if options and 'save_state' in options:
+            save_state = options['save_state']
+        elif self.save_state_path:
+            save_state = self.save_state_path
+
+        # Reset game — use save state when available (much faster than
+        # replaying the intro sequence every episode)
         logger.info("Starting game reset...")
         try:
-            success = self.game.reset_game()
+            if save_state:
+                success = self.game.load_save_state(save_state)
+                if success:
+                    self.successful_resets += 1
+                    logger.info(f"Loaded save state: {save_state}")
+                else:
+                    logger.warning("Save state load failed, falling back to full reset")
+                    success = self.game.reset_game()
+            else:
+                success = self.game.reset_game()
             if success:
                 self.successful_resets += 1
                 logger.info("Game reset successful!")
@@ -350,7 +380,6 @@ class PokemonRedGymEnv(gym.Env):
                 logger.warning("Game reset may have failed - continuing anyway")
         except Exception as e:
             logger.error(f"Game reset failed: {e}")
-            # Try to continue anyway
             success = False
 
         # Wait for game to stabilize

--- a/pokemon_red_ai/game/agent.py
+++ b/pokemon_red_ai/game/agent.py
@@ -426,6 +426,69 @@ class PokemonRedAgent:
             logger.error(f"Failed to load state: {e}")
             return False
 
+    def load_save_state(self, path: str) -> bool:
+        """
+        Load game state from a ``.state`` file path.
+
+        Unlike ``load_state()`` which uses numbered slots and requires
+        ``enable_save_states=True``, this method loads from an arbitrary
+        file path and always works.  Used by the gym environment's
+        ``reset()`` for curriculum learning and fast episode resets.
+
+        Args:
+            path: Path to a PyBoy ``.state`` file.
+
+        Returns:
+            True if successful.
+        """
+        try:
+            with open(path, "rb") as f:
+                self.pyboy.load_state(f)
+
+            # Update memory/screen references (should still be valid
+            # but reassign for safety after state load)
+            self.memory = self.pyboy.memory
+            self.screen = self.pyboy.screen
+
+            # Reset RL tracking for new episode
+            self.visited_locations.clear()
+            self.previous_stats.clear()
+            self.episode_steps = 0
+            self.is_initialized = True
+
+            logger.info(f"Save state loaded from {path}")
+            return True
+        except FileNotFoundError:
+            logger.error(f"Save state file not found: {path}")
+            return False
+        except Exception as e:
+            logger.error(f"Failed to load save state: {e}")
+            return False
+
+    def save_save_state(self, path: str) -> bool:
+        """
+        Save current game state to a ``.state`` file path.
+
+        Companion to ``load_save_state()``.  Useful for creating
+        curriculum save states (post-intro, post-starter, etc.).
+
+        Args:
+            path: Path to write the ``.state`` file.
+
+        Returns:
+            True if successful.
+        """
+        try:
+            from pathlib import Path
+            Path(path).parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "wb") as f:
+                self.pyboy.save_state(f)
+            logger.info(f"Save state written to {path}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to save state: {e}")
+            return False
+
     def step(self, action: str) -> Dict[str, Any]:
         """
         Execute one game step with the given action.

--- a/pokemon_red_ai/game/memory.py
+++ b/pokemon_red_ai/game/memory.py
@@ -264,6 +264,9 @@ def get_comprehensive_state(memory) -> Dict[str, Union[int, float, str, Dict]]:
     """
     Get comprehensive game state information.
 
+    Includes event flags and battle state when the ``event_flags``
+    module is available (added in PR #1).
+
     Args:
         memory: PyBoy memory object
 
@@ -275,7 +278,7 @@ def get_comprehensive_state(memory) -> Dict[str, Union[int, float, str, Dict]]:
     game_state = read_game_state(memory)
     money = read_money(memory)
 
-    return {
+    state = {
         'position': position,
         'stats': stats,
         'game_state': game_state,
@@ -285,3 +288,13 @@ def get_comprehensive_state(memory) -> Dict[str, Union[int, float, str, Dict]]:
         'in_game': is_in_game(memory),
         'is_alive': stats['current_hp'] > 0,
     }
+
+    # Event flags and battle state (PR #1 additions)
+    try:
+        from .event_flags import read_boulder_path_flags, read_battle_state
+        state['event_flags'] = read_boulder_path_flags(memory)
+        state['battle_state'] = read_battle_state(memory)
+    except ImportError:
+        pass  # event_flags module not available
+
+    return state

--- a/tests/unit/environment/test_gym_env.py
+++ b/tests/unit/environment/test_gym_env.py
@@ -82,7 +82,7 @@ class TestPokemonRedGymEnvInitialization:
         env = PokemonRedGymEnv(str(mock_rom_file))
 
         assert isinstance(env.action_space, gym.spaces.Discrete)
-        assert env.action_space.n == 8  # 8 Game Boy buttons
+        assert env.action_space.n == 7  # 7 buttons (SELECT removed)
 
     def test_observation_space_multi_modal(self, mock_agent_class, mock_rom_file):
         """Test multi-modal observation space."""
@@ -162,9 +162,9 @@ class TestPokemonRedGymEnvStep:
         """Test that step calls agent properly."""
         env.reset()
 
-        env.step(2)  # SELECT button
+        env.step(2)  # START button (index 2 after SELECT removal)
 
-        env.game.step.assert_called_once_with('SELECT')
+        env.game.step.assert_called_once_with('START')
 
     def test_step_updates_visited_locations(self, env):
         """Test that visited locations are tracked."""
@@ -475,7 +475,7 @@ class TestPokemonRedGymEnvHelpers:
         meanings = env.get_action_meanings()
 
         assert isinstance(meanings, list)
-        assert len(meanings) == 8
+        assert len(meanings) == 7  # SELECT removed
         assert 'A' in meanings
         assert 'B' in meanings
 


### PR DESCRIPTION
## Summary
- **Event flags wired in**: `get_comprehensive_state()` now populates `event_flags` and `battle_state` keys, so `EventProgressRewardCalculator` receives live flag data during training
- **Save state loading**: new `save_state_path` parameter on the env — `reset()` loads a `.state` file instead of replaying the 30-second intro sequence every episode
- **SELECT removed**: action space changed from `Discrete(8)` to `Discrete(7)`, matching `analysis_plan.md` §5.2

## What this unlocks
PR #1 added the event flag reader and reward calculator, but they were disconnected — the environment never passed flag data to the calculator. This PR closes that gap. Combined with save state loading, the training loop is now fast enough for serious experiments.

## Key changes

| File | Change |
|---|---|
| `pokemon_red_ai/game/memory.py` | `get_comprehensive_state()` includes `event_flags` + `battle_state` |
| `pokemon_red_ai/game/agent.py` | New `load_save_state(path)` and `save_save_state(path)` methods |
| `pokemon_red_ai/environment/gym_env.py` | `save_state_path` param, save-state-aware `reset()`, `Discrete(7)`, event progress in info dict |
| `tests/unit/environment/test_gym_env.py` | Updated for 7-action space |

## Test plan
- [x] 418 tests passing, 0 regressions
- [x] Action space tests updated for SELECT removal
- [ ] Integration test with actual ROM + save state (requires a real ROM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)