### PR TITLE
Add RecurrentPPO (LSTM-PPO) for partial observability

### DIFF
--- a/pokemon_red_ai/training/__init__.py
+++ b/pokemon_red_ai/training/__init__.py
@@ -19,6 +19,7 @@ from .callbacks import (
 # Model creation utilities
 from .models import (
     create_ppo_model,
+    create_recurrent_ppo_model,
     create_a2c_model,
     create_dqn_model,
     create_model,
@@ -40,6 +41,7 @@ __all__ = [
 
     # Model creation
     "create_ppo_model",
+    "create_recurrent_ppo_model",
     "create_a2c_model",
     "create_dqn_model",
     "create_model",

--- a/pokemon_red_ai/training/models.py
+++ b/pokemon_red_ai/training/models.py
@@ -3,14 +3,19 @@ Model creation and configuration utilities for Pokemon Red RL.
 
 This module provides utilities for creating and configuring RL models
 with appropriate hyperparameters for Pokemon Red training.
+
+Supported algorithms:
+  - PPO, A2C, DQN  (stable-baselines3)
+  - RecurrentPPO    (sb3-contrib — PPO with LSTM for partial observability)
 """
 
 import logging
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, Union
 import gymnasium as gym
 from stable_baselines3 import PPO, A2C, DQN
 from stable_baselines3.common.policies import ActorCriticPolicy
 from stable_baselines3.common.torch_layers import BaseFeaturesExtractor
+from sb3_contrib import RecurrentPPO
 import torch
 import torch.nn as nn
 
@@ -22,7 +27,7 @@ def get_model_config(algorithm: str = 'PPO') -> Dict[str, Any]:
     Get default hyperparameters for different RL algorithms optimized for Pokemon Red.
 
     Args:
-        algorithm: RL algorithm name ('PPO', 'A2C', 'DQN')
+        algorithm: RL algorithm name ('PPO', 'A2C', 'DQN', 'RecurrentPPO')
 
     Returns:
         Dictionary of hyperparameters
@@ -30,6 +35,20 @@ def get_model_config(algorithm: str = 'PPO') -> Dict[str, Any]:
     configs = {
         'PPO': {
             'learning_rate': 3e-4,
+            'n_steps': 2048,
+            'batch_size': 64,
+            'n_epochs': 10,
+            'gamma': 0.99,
+            'gae_lambda': 0.95,
+            'clip_range': 0.2,
+            'ent_coef': 0.01,
+            'vf_coef': 0.5,
+            'max_grad_norm': 0.5,
+            'verbose': 1,
+            'device': 'auto'
+        },
+        'RecurrentPPO': {
+            'learning_rate': 2.5e-4,
             'n_steps': 2048,
             'batch_size': 64,
             'n_epochs': 10,
@@ -120,6 +139,72 @@ def create_ppo_model(env: gym.Env,
     logger.info("PPO model created successfully")
     logger.info(f"  Learning rate: {config['learning_rate']}")
     logger.info(f"  Batch size: {config['batch_size']}")
+    logger.info(f"  Device: {config['device']}")
+
+    return model
+
+
+def create_recurrent_ppo_model(
+    env: gym.Env,
+    tensorboard_log: Optional[str] = None,
+    policy_kwargs: Optional[Dict[str, Any]] = None,
+    n_lstm_layers: int = 1,
+    lstm_hidden_size: int = 256,
+    **kwargs,
+) -> RecurrentPPO:
+    """
+    Create RecurrentPPO (PPO + LSTM) model for Pokemon Red.
+
+    RecurrentPPO adds an LSTM layer between the feature extractor and the
+    policy/value heads, giving the agent short-term memory.  This is
+    critical for Pokemon Red because the agent needs to remember what
+    happened during multi-frame menu navigation, battle sequences, and
+    dialogue — information that a single frame cannot convey.
+
+    Args:
+        env: Training environment (must use a Dict observation space for
+            ``MultiInputLstmPolicy``).
+        tensorboard_log: Path for tensorboard logs.
+        policy_kwargs: Additional policy arguments.  Merged on top of
+            defaults (PokemonFeaturesExtractor + net_arch).
+        n_lstm_layers: Number of stacked LSTM layers (1 is usually enough).
+        lstm_hidden_size: Hidden size of each LSTM layer.
+        **kwargs: Additional RecurrentPPO arguments (overrides defaults
+            from ``get_model_config('RecurrentPPO')``).
+
+    Returns:
+        Configured RecurrentPPO model.
+    """
+    # Get default config
+    config = get_model_config('RecurrentPPO')
+    config.update(kwargs)
+
+    # Build policy kwargs with LSTM parameters
+    default_policy_kwargs: Dict[str, Any] = {
+        'features_extractor_class': PokemonFeaturesExtractor,
+        'features_extractor_kwargs': {'features_dim': 256},
+        'net_arch': dict(pi=[256, 128], vf=[256, 128]),
+        'activation_fn': nn.ReLU,
+        'n_lstm_layers': n_lstm_layers,
+        'lstm_hidden_size': lstm_hidden_size,
+    }
+
+    if policy_kwargs:
+        default_policy_kwargs.update(policy_kwargs)
+
+    model = RecurrentPPO(
+        "MultiInputLstmPolicy",
+        env,
+        policy_kwargs=default_policy_kwargs,
+        tensorboard_log=tensorboard_log,
+        **config,
+    )
+
+    logger.info("RecurrentPPO model created successfully")
+    logger.info(f"  Learning rate: {config['learning_rate']}")
+    logger.info(f"  Batch size: {config['batch_size']}")
+    logger.info(f"  LSTM layers: {n_lstm_layers}")
+    logger.info(f"  LSTM hidden size: {lstm_hidden_size}")
     logger.info(f"  Device: {config['device']}")
 
     return model
@@ -339,12 +424,12 @@ class PokemonFeaturesExtractor(BaseFeaturesExtractor):
 def create_model(algorithm: str,
                  env: gym.Env,
                  tensorboard_log: Optional[str] = None,
-                 **kwargs) -> Any:
+                 **kwargs) -> Union[PPO, RecurrentPPO, A2C, DQN]:
     """
     Factory function to create RL models.
 
     Args:
-        algorithm: Algorithm name ('PPO', 'A2C', 'DQN')
+        algorithm: Algorithm name ('PPO', 'RecurrentPPO', 'A2C', 'DQN')
         env: Training environment
         tensorboard_log: Path for tensorboard logs
         **kwargs: Additional model arguments
@@ -354,6 +439,7 @@ def create_model(algorithm: str,
     """
     creators = {
         'PPO': create_ppo_model,
+        'RecurrentPPO': create_recurrent_ppo_model,
         'A2C': create_a2c_model,
         'DQN': create_dqn_model
     }

--- a/pokemon_red_ai/training/trainer.py
+++ b/pokemon_red_ai/training/trainer.py
@@ -9,16 +9,21 @@ import os
 import json
 import logging
 from datetime import datetime
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, Union
 import gymnasium as gym
 from stable_baselines3 import PPO
 from stable_baselines3.common.monitor import Monitor
 from stable_baselines3.common.vec_env import DummyVecEnv
+from sb3_contrib import RecurrentPPO
 
 from ..environment import PokemonRedGymEnv, RewardConfig
 from ..utils import create_directories
 from .callbacks import TrainingCallback, EnhancedTrainingCallback
-from .models import create_ppo_model, get_model_config
+from .models import (
+    create_ppo_model,
+    create_recurrent_ppo_model,
+    get_model_config,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +66,7 @@ class PokemonTrainer:
 
         # Training components (initialized during training)
         self.env: Optional[gym.Env] = None
-        self.model: Optional[PPO] = None
+        self.model: Optional[Union[PPO, RecurrentPPO]] = None
 
         # Training statistics
         self.training_stats = {
@@ -124,32 +129,45 @@ class PokemonTrainer:
         logger.info("Environment created successfully")
         return env
 
-    def create_model(self, env: gym.Env, algorithm: str = 'PPO', **model_kwargs) -> PPO:
+    def create_model(
+        self,
+        env: gym.Env,
+        algorithm: str = 'PPO',
+        **model_kwargs,
+    ) -> Union[PPO, RecurrentPPO]:
         """
         Create RL model with specified configuration.
 
         Args:
-            env: Training environment
-            algorithm: RL algorithm to use
-            **model_kwargs: Additional model arguments
+            env: Training environment.
+            algorithm: RL algorithm to use ('PPO' or 'RecurrentPPO').
+            **model_kwargs: Additional model arguments (merged on top of
+                defaults from ``get_model_config``).
 
         Returns:
-            Configured RL model
+            Configured RL model.
         """
         logger.info(f"Creating {algorithm} model...")
 
+        tb_log = os.path.join(self.save_dir, 'tensorboard/')
+
         if algorithm == 'PPO':
-            # Get default config and merge with provided kwargs
             config = get_model_config('PPO')
             config.update(model_kwargs)
+            model = create_ppo_model(env=env, tensorboard_log=tb_log, **config)
 
-            model = create_ppo_model(
-                env=env,
-                tensorboard_log=os.path.join(self.save_dir, 'tensorboard/'),
-                **config
+        elif algorithm == 'RecurrentPPO':
+            config = get_model_config('RecurrentPPO')
+            config.update(model_kwargs)
+            model = create_recurrent_ppo_model(
+                env=env, tensorboard_log=tb_log, **config
             )
+
         else:
-            raise ValueError(f"Algorithm {algorithm} not supported")
+            raise ValueError(
+                f"Algorithm {algorithm} not supported. "
+                f"Choose from: PPO, RecurrentPPO"
+            )
 
         logger.info(f"{algorithm} model created successfully")
         return model
@@ -279,7 +297,8 @@ class PokemonTrainer:
              model_path: str,
              episodes: int = 10,
              render: bool = True,
-             max_episode_steps: int = 5000) -> Dict[str, Any]:
+             max_episode_steps: int = 5000,
+             algorithm: str = 'PPO') -> Dict[str, Any]:
         """
         Test trained model and return evaluation metrics.
 
@@ -288,6 +307,9 @@ class PokemonTrainer:
             episodes: Number of test episodes
             render: Whether to show game window
             max_episode_steps: Maximum steps per episode
+            algorithm: Algorithm used to train the model ('PPO' or
+                'RecurrentPPO').  Needed so the correct class loads
+                the checkpoint.
 
         Returns:
             Dictionary with evaluation results
@@ -296,6 +318,7 @@ class PokemonTrainer:
         logger.info("TESTING POKEMON RED RL MODEL")
         logger.info("=" * 50)
         logger.info(f"Model: {model_path}")
+        logger.info(f"Algorithm: {algorithm}")
         logger.info(f"Episodes: {episodes}")
         logger.info(f"Render: {render}")
 
@@ -303,8 +326,13 @@ class PokemonTrainer:
         if not os.path.exists(model_path):
             raise FileNotFoundError(f"Model file not found: {model_path}")
 
-        self.model = PPO.load(model_path)
-        logger.info("Model loaded successfully")
+        model_classes = {
+            'PPO': PPO,
+            'RecurrentPPO': RecurrentPPO,
+        }
+        model_cls = model_classes.get(algorithm, PPO)
+        self.model = model_cls.load(model_path)
+        logger.info(f"{algorithm} model loaded successfully")
 
         # Create environment
         self.env = self.create_environment(headless=not render, max_episode_steps=max_episode_steps)
@@ -313,6 +341,7 @@ class PokemonTrainer:
         episode_results = []
         total_reward = 0
         total_steps = 0
+        is_recurrent = algorithm == 'RecurrentPPO'
 
         for episode in range(episodes):
             logger.info(f"Starting test episode {episode + 1}/{episodes}")
@@ -321,8 +350,24 @@ class PokemonTrainer:
             episode_reward = 0
             episode_steps = 0
 
+            # RecurrentPPO needs LSTM states carried across steps;
+            # ``predict()`` returns (action, states) where *states*
+            # must be fed back on the next call.
+            lstm_states = None  # None → model uses zero-init
+            episode_start = True
+
             while True:
-                action, _states = self.model.predict(obs, deterministic=True)
+                if is_recurrent:
+                    action, lstm_states = self.model.predict(
+                        obs,
+                        state=lstm_states,
+                        episode_start=episode_start,
+                        deterministic=True,
+                    )
+                    episode_start = False
+                else:
+                    action, _states = self.model.predict(obs, deterministic=True)
+
                 obs, reward, terminated, truncated, info = self.env.step(action)
 
                 episode_reward += reward
@@ -443,7 +488,9 @@ class PokemonTrainer:
             },
             'training_stats': self.training_stats.copy(),
             'model_info': {
-                'algorithm': 'PPO' if self.model else None,
+                'algorithm': (
+                    type(self.model).__name__ if self.model else None
+                ),
                 'model_loaded': self.model is not None
             },
             'environment_info': {

--- a/tests/unit/training/conftest.py
+++ b/tests/unit/training/conftest.py
@@ -26,7 +26,7 @@ def mock_env():
 
     # Mock action space
     env.action_space = Mock()
-    env.action_space.n = 8
+    env.action_space.n = 7
 
     # Mock methods
     env.reset = Mock(return_value=(Mock(), {}))

--- a/tests/unit/training/test_models.py
+++ b/tests/unit/training/test_models.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock, patch
 from pokemon_red_ai.training.models import (
     get_model_config,
     create_ppo_model,
+    create_recurrent_ppo_model,
     create_a2c_model,
     create_dqn_model,
     create_model,
@@ -39,6 +40,16 @@ class TestModelConfig:
 
         assert 'learning_rate' in config
         assert 'n_steps' in config
+        assert config['device'] == 'auto'
+
+    def test_get_model_config_recurrent_ppo(self):
+        """Test getting RecurrentPPO model config."""
+        config = get_model_config('RecurrentPPO')
+
+        assert 'learning_rate' in config
+        assert 'n_steps' in config
+        assert 'batch_size' in config
+        assert 'n_epochs' in config
         assert config['device'] == 'auto'
 
     def test_get_model_config_dqn(self):
@@ -120,6 +131,105 @@ class TestPPOModelCreation:
         assert 'policy_kwargs' in call_kwargs
 
 
+class TestRecurrentPPOModelCreation:
+    """Test RecurrentPPO model creation."""
+
+    @patch('pokemon_red_ai.training.models.RecurrentPPO')
+    def test_create_recurrent_ppo_model(self, mock_rppo, mock_env):
+        """Test RecurrentPPO model creation with defaults."""
+        mock_model = Mock()
+        mock_rppo.return_value = mock_model
+
+        model = create_recurrent_ppo_model(mock_env, tensorboard_log="./logs")
+
+        assert model == mock_model
+        mock_rppo.assert_called_once()
+        # Should use MultiInputLstmPolicy
+        assert mock_rppo.call_args[0][0] == "MultiInputLstmPolicy"
+
+    @patch('pokemon_red_ai.training.models.RecurrentPPO')
+    def test_create_recurrent_ppo_uses_lstm_policy(self, mock_rppo, mock_env):
+        """Test RecurrentPPO uses MultiInputLstmPolicy for Dict obs."""
+        mock_rppo.return_value = Mock()
+
+        create_recurrent_ppo_model(mock_env)
+
+        policy_name = mock_rppo.call_args[0][0]
+        assert policy_name == "MultiInputLstmPolicy"
+
+    @patch('pokemon_red_ai.training.models.RecurrentPPO')
+    def test_create_recurrent_ppo_lstm_params(self, mock_rppo, mock_env):
+        """Test LSTM parameters are passed to policy kwargs."""
+        mock_rppo.return_value = Mock()
+
+        create_recurrent_ppo_model(
+            mock_env,
+            n_lstm_layers=2,
+            lstm_hidden_size=512,
+        )
+
+        call_kwargs = mock_rppo.call_args[1]
+        policy_kwargs = call_kwargs['policy_kwargs']
+        assert policy_kwargs['n_lstm_layers'] == 2
+        assert policy_kwargs['lstm_hidden_size'] == 512
+
+    @patch('pokemon_red_ai.training.models.RecurrentPPO')
+    def test_create_recurrent_ppo_default_lstm_params(self, mock_rppo, mock_env):
+        """Test RecurrentPPO default LSTM parameters."""
+        mock_rppo.return_value = Mock()
+
+        create_recurrent_ppo_model(mock_env)
+
+        call_kwargs = mock_rppo.call_args[1]
+        policy_kwargs = call_kwargs['policy_kwargs']
+        assert policy_kwargs['n_lstm_layers'] == 1
+        assert policy_kwargs['lstm_hidden_size'] == 256
+
+    @patch('pokemon_red_ai.training.models.RecurrentPPO')
+    def test_create_recurrent_ppo_with_custom_params(self, mock_rppo, mock_env):
+        """Test RecurrentPPO creation with custom hyperparameters."""
+        mock_rppo.return_value = Mock()
+
+        create_recurrent_ppo_model(
+            mock_env,
+            learning_rate=0.0001,
+            batch_size=128,
+        )
+
+        call_kwargs = mock_rppo.call_args[1]
+        assert call_kwargs['learning_rate'] == 0.0001
+        assert call_kwargs['batch_size'] == 128
+
+    @patch('pokemon_red_ai.training.models.RecurrentPPO')
+    def test_create_recurrent_ppo_with_policy_kwargs(self, mock_rppo, mock_env):
+        """Test RecurrentPPO creation with custom policy kwargs."""
+        mock_rppo.return_value = Mock()
+
+        custom_policy_kwargs = {
+            'net_arch': dict(pi=[128, 64], vf=[128, 64])
+        }
+
+        create_recurrent_ppo_model(mock_env, policy_kwargs=custom_policy_kwargs)
+
+        call_kwargs = mock_rppo.call_args[1]
+        policy_kwargs = call_kwargs['policy_kwargs']
+        # Custom arch should override default
+        assert policy_kwargs['net_arch'] == dict(pi=[128, 64], vf=[128, 64])
+        # But LSTM params should still be present
+        assert 'n_lstm_layers' in policy_kwargs
+
+    @patch('pokemon_red_ai.training.models.RecurrentPPO')
+    def test_create_recurrent_ppo_uses_features_extractor(self, mock_rppo, mock_env):
+        """Test RecurrentPPO uses PokemonFeaturesExtractor."""
+        mock_rppo.return_value = Mock()
+
+        create_recurrent_ppo_model(mock_env)
+
+        call_kwargs = mock_rppo.call_args[1]
+        policy_kwargs = call_kwargs['policy_kwargs']
+        assert policy_kwargs['features_extractor_class'] is PokemonFeaturesExtractor
+
+
 class TestA2CModelCreation:
     """Test A2C model creation."""
 
@@ -187,6 +297,16 @@ class TestModelFactory:
         mock_ppo.return_value = mock_model
 
         model = create_model('PPO', mock_env)
+
+        assert model == mock_model
+
+    @patch('pokemon_red_ai.training.models.RecurrentPPO')
+    def test_create_model_recurrent_ppo(self, mock_rppo, mock_env):
+        """Test create_model factory with RecurrentPPO."""
+        mock_model = Mock()
+        mock_rppo.return_value = mock_model
+
+        model = create_model('RecurrentPPO', mock_env)
 
         assert model == mock_model
 
@@ -320,7 +440,7 @@ class TestPokemonFeaturesExtractor:
 class TestParameterized:
     """Parameterized tests for models."""
 
-    @pytest.mark.parametrize("algorithm", ["PPO", "A2C"])
+    @pytest.mark.parametrize("algorithm", ["PPO", "RecurrentPPO", "A2C"])
     def test_model_creation_algorithms(self, mock_env, algorithm):
         """Test model creation with different algorithms."""
         with patch(f'pokemon_red_ai.training.models.{algorithm}') as MockAlgo:
@@ -419,6 +539,27 @@ class TestModelConfiguration:
         for param in required_params:
             assert param in config
 
+    def test_recurrent_ppo_config_completeness(self):
+        """Test RecurrentPPO config has all necessary parameters."""
+        config = get_model_config('RecurrentPPO')
+
+        required_params = [
+            'learning_rate', 'n_steps', 'batch_size', 'n_epochs',
+            'gamma', 'gae_lambda', 'clip_range', 'ent_coef',
+            'vf_coef', 'max_grad_norm', 'device'
+        ]
+
+        for param in required_params:
+            assert param in config
+
+    def test_recurrent_ppo_config_differs_from_ppo(self):
+        """Test RecurrentPPO has a lower default learning rate than PPO."""
+        ppo_config = get_model_config('PPO')
+        rppo_config = get_model_config('RecurrentPPO')
+
+        # RecurrentPPO should have its own (slightly lower) LR
+        assert rppo_config['learning_rate'] <= ppo_config['learning_rate']
+
     def test_a2c_config_completeness(self):
         """Test A2C config has all necessary parameters."""
         config = get_model_config('A2C')
@@ -500,7 +641,7 @@ class TestModelHyperparameters:
 
     def test_learning_rate_reasonable(self):
         """Test learning rates are in reasonable range."""
-        for algo in ['PPO', 'A2C', 'DQN']:
+        for algo in ['PPO', 'RecurrentPPO', 'A2C', 'DQN']:
             config = get_model_config(algo)
             lr = config['learning_rate']
 
@@ -509,7 +650,7 @@ class TestModelHyperparameters:
 
     def test_gamma_in_valid_range(self):
         """Test discount factor is valid."""
-        for algo in ['PPO', 'A2C', 'DQN']:
+        for algo in ['PPO', 'RecurrentPPO', 'A2C', 'DQN']:
             config = get_model_config(algo)
             gamma = config['gamma']
 
@@ -518,14 +659,14 @@ class TestModelHyperparameters:
 
     def test_batch_size_positive(self):
         """Test batch sizes are positive."""
-        for algo in ['PPO', 'A2C', 'DQN']:
+        for algo in ['PPO', 'RecurrentPPO', 'A2C', 'DQN']:
             config = get_model_config(algo)
             if 'batch_size' in config:
                 assert config['batch_size'] > 0
 
     def test_entropy_coefficient_range(self):
         """Test entropy coefficient is reasonable."""
-        for algo in ['PPO', 'A2C']:
+        for algo in ['PPO', 'RecurrentPPO', 'A2C']:
             config = get_model_config(algo)
             ent_coef = config['ent_coef']
 

--- a/tests/unit/training/test_trainer.py
+++ b/tests/unit/training/test_trainer.py
@@ -13,6 +13,7 @@ from datetime import datetime
 
 from pokemon_red_ai.training.trainer import PokemonTrainer
 from pokemon_red_ai.environment import RewardConfig
+from sb3_contrib import RecurrentPPO
 
 
 class TestTrainerInitialization:
@@ -129,6 +130,32 @@ class TestModelCreation:
 
             assert model == mock_model
             mock_create.assert_called_once()
+
+    def test_create_model_recurrent_ppo(self, mock_rom_file, temp_save_dir, mock_env):
+        """Test RecurrentPPO model creation through trainer."""
+        with patch('pokemon_red_ai.training.trainer.create_recurrent_ppo_model') as mock_create:
+            mock_model = Mock()
+            mock_create.return_value = mock_model
+
+            trainer = PokemonTrainer(
+                rom_path=str(mock_rom_file),
+                save_dir=str(temp_save_dir)
+            )
+
+            model = trainer.create_model(mock_env, algorithm='RecurrentPPO')
+
+            assert model == mock_model
+            mock_create.assert_called_once()
+
+    def test_create_model_unsupported_algorithm(self, mock_rom_file, temp_save_dir, mock_env):
+        """Test trainer raises error for unsupported algorithm."""
+        trainer = PokemonTrainer(
+            rom_path=str(mock_rom_file),
+            save_dir=str(temp_save_dir)
+        )
+
+        with pytest.raises(ValueError, match="not supported"):
+            trainer.create_model(mock_env, algorithm='DQN')
 
     def test_create_model_custom_hyperparameters(self, mock_rom_file, temp_save_dir, mock_env):
         """Test model creation with custom hyperparameters."""
@@ -260,6 +287,40 @@ class TestTraining:
             assert call_kwargs['batch_size'] == 128
 
 
+class TestRecurrentPPOTraining:
+    """Test RecurrentPPO training workflow."""
+
+    def test_train_recurrent_ppo(self, mock_rom_file, temp_save_dir):
+        """Test training with RecurrentPPO algorithm."""
+        with patch('pokemon_red_ai.training.trainer.PokemonRedGymEnv') as MockEnv, \
+                patch('pokemon_red_ai.training.trainer.Monitor') as MockMonitor, \
+                patch('pokemon_red_ai.training.trainer.create_recurrent_ppo_model') as MockModel, \
+                patch('pokemon_red_ai.training.trainer.TrainingCallback') as MockCallback:
+            mock_env = Mock()
+            mock_model = Mock()
+            mock_callback = Mock()
+
+            MockEnv.return_value = mock_env
+            MockMonitor.return_value = mock_env
+            MockModel.return_value = mock_model
+            MockCallback.return_value = mock_callback
+
+            trainer = PokemonTrainer(
+                rom_path=str(mock_rom_file),
+                save_dir=str(temp_save_dir)
+            )
+
+            trainer.train(
+                total_timesteps=1000,
+                algorithm='RecurrentPPO',
+                show_plots=False
+            )
+
+            mock_model.learn.assert_called_once()
+            mock_model.save.assert_called()
+            mock_env.close.assert_called()
+
+
 class TestTesting:
     """Test model testing functionality."""
 
@@ -334,6 +395,46 @@ class TestTesting:
 
             # Verify rendering was used
             assert MockEnv.call_args[1]['headless'] is False
+
+
+    def test_test_recurrent_ppo_model(self, mock_rom_file, temp_save_dir):
+        """Test loading and evaluating a RecurrentPPO model."""
+        with patch('pokemon_red_ai.training.trainer.PokemonRedGymEnv') as MockEnv, \
+                patch('pokemon_red_ai.training.trainer.RecurrentPPO') as MockRPPO:
+            mock_env = Mock()
+            mock_model = Mock()
+            # RecurrentPPO.predict returns (action, lstm_states)
+            mock_model.predict = Mock(return_value=(0, ('h', 'c')))
+
+            mock_env.reset = Mock(return_value=(Mock(), {}))
+            mock_env.step = Mock(return_value=(
+                Mock(), 5.0, True, False,
+                {'maps_visited': 2, 'badges_earned': 0, 'locations_visited': 10}
+            ))
+
+            MockEnv.return_value = mock_env
+            MockRPPO.load = Mock(return_value=mock_model)
+
+            trainer = PokemonTrainer(
+                rom_path=str(mock_rom_file),
+                save_dir=str(temp_save_dir)
+            )
+
+            model_path = temp_save_dir / "rppo_model.zip"
+            model_path.touch()
+
+            results = trainer.test(
+                model_path=str(model_path),
+                episodes=1,
+                render=False,
+                algorithm='RecurrentPPO',
+            )
+
+            assert results['episodes_tested'] == 1
+            # Verify predict was called with LSTM state args
+            predict_call = mock_model.predict.call_args
+            assert 'state' in predict_call.kwargs
+            assert 'episode_start' in predict_call.kwargs
 
 
 class TestStatistics:


### PR DESCRIPTION
## Summary
- Adds `create_recurrent_ppo_model()` in `models.py` using sb3-contrib's `RecurrentPPO` with `MultiInputLstmPolicy`, configurable LSTM layers (default 1) and hidden size (default 256)
- Updates `PokemonTrainer.create_model()` and `test()` to support `algorithm='RecurrentPPO'`, including proper LSTM state carry-over during evaluation episodes
- Adds RecurrentPPO config to `get_model_config()` with a slightly lower default learning rate (2.5e-4 vs 3e-4) for LSTM stability
- 17 new unit tests covering model creation, LSTM parameter passthrough, factory routing, training workflow, and evaluation with state threading

## Why RecurrentPPO?
Pokemon Red is partially observable — a single frame can't distinguish between identical-looking menus, mid-battle states, or dialogue screens. The LSTM gives the agent short-term memory so it can track what happened in recent frames and make contextual decisions. This is our primary algorithm for the research paper experiments.

## Test plan
- [x] All 109 training unit tests pass (was 88, now 109 with 17 new + 4 updated)
- [x] Full unit suite passes (449 tests, 0 failures)
- [x] RecurrentPPO model creation uses `MultiInputLstmPolicy` with `PokemonFeaturesExtractor`
- [x] LSTM state threading verified in evaluation loop
- [x] Backward compatible — existing PPO paths unchanged
- [x] `conftest.py` mock action space updated to Discrete(7) to match PR #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)