### PR TITLE
Add curriculum save states script (AMC-57)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 pokemon_training/
 PokemonRed.gb*
+*.state
+save_states/*.state
 .idea/
 pokemon_red_ai/__pycache__/
 pokemon_red_ai/cli/__pycache__/

--- a/scripts/create_save_states.py
+++ b/scripts/create_save_states.py
@@ -346,8 +346,13 @@ def run_interactive(rom_path: str, save_dir: str, save_name: str) -> bool:
         while True:
             agent.pyboy.tick()
 
+
     except KeyboardInterrupt:
         logger.info("\nCtrl+C received — saving state...")
+
+        if agent is None:
+            logger.error("Cannot save: agent not initialized")
+            return False
 
         pos = read_player_position(agent.memory)
         stats = read_player_stats(agent.memory)
@@ -359,6 +364,7 @@ def run_interactive(rom_path: str, save_dir: str, save_name: str) -> bool:
         )
 
         ok = agent.save_save_state(state_path)
+
         if ok:
             try:
                 size_str = f" ({os.path.getsize(state_path):,} bytes)"

--- a/scripts/create_save_states.py
+++ b/scripts/create_save_states.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+"""
+Create curriculum save states for Pokemon Red RL training.
+
+Runs the ROM through the opening sequence and saves PyBoy ``.state``
+files at key game checkpoints.  These save states let the training
+script skip the intro on every episode reset, dramatically reducing
+wall-clock time.
+
+Automatically created save states
+----------------------------------
+``s0_post_intro.state``
+    Player is in their bedroom in Pallet Town, immediately after
+    Prof. Oak's intro and naming screens.  This is the standard
+    starting point for RL training.
+
+Manual save states (via ``--interactive``)
+------------------------------------------
+The script can also drop into an interactive loop where you play
+the game and press ``Ctrl+C`` to save at arbitrary checkpoints.
+This is useful for creating curriculum states deeper in the game
+(e.g. pre-Brock, post-Brock) that are too complex to automate.
+
+Usage::
+
+    # Automatic (creates post-intro save state)
+    python scripts/create_save_states.py --rom PokemonRed.gb
+
+    # Interactive (play the game and save manually)
+    python scripts/create_save_states.py --rom PokemonRed.gb --interactive
+
+    # Validate existing save states
+    python scripts/create_save_states.py --rom PokemonRed.gb --validate-only
+"""
+
+import argparse
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+
+# Add project root to path
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from pokemon_red_ai.game.agent import PokemonRedAgent
+from pokemon_red_ai.game.memory import (
+    MAP_IDS,
+    BADGE_FLAGS,
+    read_player_position,
+    read_player_stats,
+    read_memory_value,
+    MEMORY_ADDRESSES,
+)
+
+logger = logging.getLogger(__name__)
+
+# ──────────────────────────────────────────────────────────────────────
+# Save state definitions
+# ──────────────────────────────────────────────────────────────────────
+
+# Each entry defines the expected game state for validation.
+# Map 40 = Red's House 2F (player's bedroom) — this is the actual
+# starting map, not the Pallet Town overworld (map 1).
+REDS_HOUSE_2F = 40
+
+SAVE_STATE_SPECS = {
+    "s0_post_intro": {
+        "filename": "s0_post_intro.state",
+        "description": "Post-intro: Pallet Town, player's bedroom",
+        "expected_map_id": REDS_HOUSE_2F,
+        "expected_badges": 0,
+        "min_party_count": 0,  # No Pokemon yet
+    },
+    "s1_post_starter": {
+        "filename": "s1_post_starter.state",
+        "description": "Post-starter: Pallet Town, has first Pokemon",
+        "expected_map_id": None,  # Could be in Oak's lab or Pallet
+        "expected_badges": 0,
+        "min_party_count": 1,
+    },
+    "s2_pre_brock": {
+        "filename": "s2_pre_brock.state",
+        "description": "Pre-Brock: Pewter City, before gym battle",
+        "expected_map_id": MAP_IDS["pewter_city"],
+        "expected_badges": 0,
+        "min_party_count": 1,
+    },
+    "s3_post_brock": {
+        "filename": "s3_post_brock.state",
+        "description": "Post-Brock: has Boulder Badge",
+        "expected_map_id": None,  # Could be in gym or Pewter
+        "expected_badges": BADGE_FLAGS["boulder"],
+        "min_party_count": 1,
+    },
+}
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Validation
+# ──────────────────────────────────────────────────────────────────────
+
+
+def validate_save_state(
+    rom_path: str,
+    state_path: str,
+    spec: dict,
+) -> bool:
+    """
+    Load a save state and verify the game is in the expected condition.
+
+    Returns True if all checks pass.
+    """
+    if not os.path.isfile(state_path):
+        logger.warning(f"  State file not found: {state_path}")
+        return False
+
+    file_size = os.path.getsize(state_path)
+    if file_size == 0:
+        logger.error(f"  State file is empty: {state_path}")
+        return False
+
+    agent = None
+    try:
+        agent = PokemonRedAgent(rom_path, show_window=False, speed_multiplier=0)
+        success = agent.load_save_state(state_path)
+        if not success:
+            logger.error(f"  PyBoy failed to load state: {state_path}")
+            return False
+
+        # Let the game settle after state load
+        agent.wait_frames(30)
+
+        # Read game state
+        pos = read_player_position(agent.memory)
+        stats = read_player_stats(agent.memory)
+
+        logger.info(f"  Map ID: {pos['map']}  Position: ({pos['x']}, {pos['y']})")
+        logger.info(
+            f"  Party: {stats['party_count']}  "
+            f"Badges: {stats['badges']:08b}  "
+            f"Level: {stats['level']}"
+        )
+
+        passed = True
+
+        # Check map
+        expected_map = spec.get("expected_map_id")
+        if expected_map is not None and pos["map"] != expected_map:
+            logger.error(
+                f"  FAIL map_id: expected {expected_map}, got {pos['map']}"
+            )
+            passed = False
+
+        # Check badges
+        expected_badges = spec.get("expected_badges", 0)
+        if expected_badges > 0:
+            if not (stats["badges"] & expected_badges):
+                logger.error(
+                    f"  FAIL badges: expected {expected_badges:#04x} set, "
+                    f"got {stats['badges']:#04x}"
+                )
+                passed = False
+        elif expected_badges == 0 and stats["badges"] != 0:
+            # If we expect 0 badges but have some, that's a warning not a failure
+            logger.warning(
+                f"  WARN badges: expected 0, got {stats['badges']:#04x}"
+            )
+
+        # Check party
+        min_party = spec.get("min_party_count", 0)
+        if stats["party_count"] < min_party:
+            logger.error(
+                f"  FAIL party_count: expected >= {min_party}, "
+                f"got {stats['party_count']}"
+            )
+            passed = False
+
+        if passed:
+            logger.info("  PASS")
+        return passed
+
+    except Exception as e:
+        logger.error(f"  Validation error: {e}")
+        return False
+    finally:
+        if agent is not None:
+            try:
+                agent.pyboy.stop()
+            except Exception:
+                pass
+
+
+def validate_all(rom_path: str, save_dir: str) -> dict:
+    """Validate all save states that exist in the directory."""
+    results = {}
+    for key, spec in SAVE_STATE_SPECS.items():
+        state_path = os.path.join(save_dir, spec["filename"])
+        if os.path.isfile(state_path):
+            logger.info(f"Validating {spec['description']}...")
+            results[key] = validate_save_state(rom_path, state_path, spec)
+        else:
+            logger.info(f"Skipping {spec['description']} (file not found)")
+            results[key] = None
+
+    return results
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Automatic creation
+# ──────────────────────────────────────────────────────────────────────
+
+
+def create_post_intro_state(rom_path: str, save_dir: str) -> bool:
+    """
+    Run the opening sequence and save state right after the intro.
+
+    The agent automates:
+    1. Title screen / copyright notices
+    2. Prof. Oak's introduction
+    3. Player and rival naming (accepts defaults: RED / BLUE)
+    4. Intro dialogue completion
+
+    Saves ``s0_post_intro.state`` when the player is standing in
+    Pallet Town with game control active.
+    """
+    spec = SAVE_STATE_SPECS["s0_post_intro"]
+    state_path = os.path.join(save_dir, spec["filename"])
+
+    logger.info("=" * 60)
+    logger.info("Creating post-intro save state")
+    logger.info("=" * 60)
+
+    agent = None
+    try:
+        agent = PokemonRedAgent(
+            rom_path, show_window=False, speed_multiplier=0
+        )
+
+        logger.info("Running opening sequence (this takes ~30-60 seconds)...")
+        start = time.time()
+        success = agent.run_opening_sequence()
+        elapsed = time.time() - start
+
+        if not success:
+            logger.error(
+                f"Opening sequence failed after {elapsed:.1f}s. "
+                "The ROM may not be compatible or PyBoy may need updating."
+            )
+            return False
+
+        logger.info(f"Opening sequence completed in {elapsed:.1f}s")
+
+        # Verify we're in the game
+        pos = read_player_position(agent.memory)
+        stats = read_player_stats(agent.memory)
+        logger.info(
+            f"Position: map={pos['map']} ({pos['x']}, {pos['y']})  "
+            f"Party: {stats['party_count']}"
+        )
+
+        if pos["map"] == 0:
+            logger.error(
+                "map_id is 0 after opening sequence -- player is not in-game. "
+                "The intro may not have completed properly."
+            )
+            return False
+
+        # Save the state
+        logger.info(f"Saving state to {state_path}...")
+        ok = agent.save_save_state(state_path)
+        if not ok:
+            logger.error("save_save_state() returned False")
+            return False
+
+        try:
+            size = os.path.getsize(state_path)
+            logger.info(f"State saved ({size:,} bytes)")
+        except OSError:
+            logger.info("State saved (size unknown)")
+
+        return True
+
+    except Exception as e:
+        logger.error(f"Failed to create post-intro state: {e}")
+        return False
+    finally:
+        if agent is not None:
+            try:
+                agent.pyboy.stop()
+            except Exception:
+                pass
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Interactive mode
+# ──────────────────────────────────────────────────────────────────────
+
+
+def run_interactive(rom_path: str, save_dir: str, save_name: str) -> bool:
+    """
+    Open the game with a visible window and let the user play.
+
+    The user plays normally and presses ``Ctrl+C`` when they want
+    to save a state.  The state is saved under ``save_name`` in
+    ``save_dir``.
+
+    If a post-intro state exists, it is loaded first to skip the
+    opening sequence.
+    """
+    state_path = os.path.join(save_dir, save_name)
+    post_intro = os.path.join(save_dir, "s0_post_intro.state")
+
+    logger.info("=" * 60)
+    logger.info("Interactive mode")
+    logger.info(f"  Save target: {state_path}")
+    logger.info("  Play the game, then press Ctrl+C to save.")
+    logger.info("=" * 60)
+
+    agent = None
+    try:
+        agent = PokemonRedAgent(
+            rom_path, show_window=True, speed_multiplier=1
+        )
+
+        # Load post-intro state if available to skip intro
+        if os.path.isfile(post_intro):
+            logger.info(f"Loading post-intro state to skip intro...")
+            agent.load_save_state(post_intro)
+            agent.wait_frames(30)
+        else:
+            logger.info("No post-intro state found, running opening sequence...")
+            agent.run_opening_sequence()
+
+        pos = read_player_position(agent.memory)
+        stats = read_player_stats(agent.memory)
+        logger.info(
+            f"Ready! Map={pos['map']} ({pos['x']},{pos['y']})  "
+            f"Party={stats['party_count']}  Badges={stats['badges']:08b}"
+        )
+        logger.info("Press Ctrl+C to save state and exit.")
+
+        # Let the user play — PyBoy handles input via SDL2 window
+        while True:
+            agent.pyboy.tick()
+
+    except KeyboardInterrupt:
+        logger.info("\nCtrl+C received — saving state...")
+
+        pos = read_player_position(agent.memory)
+        stats = read_player_stats(agent.memory)
+        logger.info(
+            f"Current state: Map={pos['map']} ({pos['x']},{pos['y']})  "
+            f"Party={stats['party_count']}  "
+            f"Level={stats['level']}  "
+            f"Badges={stats['badges']:08b}"
+        )
+
+        ok = agent.save_save_state(state_path)
+        if ok:
+            try:
+                size_str = f" ({os.path.getsize(state_path):,} bytes)"
+            except OSError:
+                size_str = ""
+            logger.info(f"State saved to {state_path}{size_str}")
+        else:
+            logger.error("Failed to save state!")
+        return ok
+
+    except Exception as e:
+        logger.error(f"Interactive mode error: {e}")
+        return False
+    finally:
+        if agent is not None:
+            try:
+                agent.pyboy.stop()
+            except Exception:
+                pass
+
+
+# ──────────────────────────────────────────────────────────────────────
+# CLI
+# ──────────────────────────────────────────────────────────────────────
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Create and validate curriculum save states for RL training.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    p.add_argument(
+        "--rom", required=True, type=str,
+        help="Path to Pokemon Red ROM (.gb) file.",
+    )
+    p.add_argument(
+        "--save-dir", type=str, default="save_states",
+        help="Directory for save state files.",
+    )
+
+    mode = p.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--interactive", action="store_true",
+        help="Open game window for manual play; Ctrl+C to save.",
+    )
+    mode.add_argument(
+        "--validate-only", action="store_true",
+        help="Only validate existing save states, don't create new ones.",
+    )
+
+    p.add_argument(
+        "--save-name", type=str, default=None,
+        help="Filename for interactive save (default: prompted).",
+    )
+    p.add_argument(
+        "--skip-validation", action="store_true",
+        help="Skip post-creation validation step.",
+    )
+    p.add_argument(
+        "-v", "--verbose", action="count", default=0,
+        help="Increase verbosity (-v INFO, -vv DEBUG).",
+    )
+
+    return p
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    # Logging
+    level = {0: logging.WARNING, 1: logging.INFO}.get(args.verbose, logging.DEBUG)
+    logging.basicConfig(
+        level=level,
+        format="[%(asctime)s] %(name)s %(levelname)s - %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    # Validate ROM
+    if not os.path.isfile(args.rom):
+        logger.error(f"ROM file not found: {args.rom}")
+        return 1
+
+    # Ensure save directory exists
+    os.makedirs(args.save_dir, exist_ok=True)
+
+    # ── Validate-only mode ──────────────────────────────────────────
+    if args.validate_only:
+        results = validate_all(args.rom, args.save_dir)
+        found = {k: v for k, v in results.items() if v is not None}
+        if not found:
+            logger.warning("No save state files found to validate.")
+            return 1
+        failed = [k for k, v in found.items() if not v]
+        if failed:
+            logger.error(f"Validation failed for: {', '.join(failed)}")
+            return 1
+        logger.info("All existing save states validated successfully.")
+        return 0
+
+    # ── Interactive mode ────────────────────────────────────────────
+    if args.interactive:
+        save_name = args.save_name
+        if not save_name:
+            # List available spec names
+            print("\nAvailable save state slots:")
+            for key, spec in SAVE_STATE_SPECS.items():
+                path = os.path.join(args.save_dir, spec["filename"])
+                exists = " [exists]" if os.path.isfile(path) else ""
+                print(f"  {spec['filename']:30s}  {spec['description']}{exists}")
+            print()
+            save_name = input("Enter filename (e.g. s2_pre_brock.state): ").strip()
+            if not save_name:
+                logger.error("No filename provided.")
+                return 1
+
+        ok = run_interactive(args.rom, args.save_dir, save_name)
+        return 0 if ok else 1
+
+    # ── Automatic mode (default) ────────────────────────────────────
+    logger.info("Creating curriculum save states...")
+
+    ok = create_post_intro_state(args.rom, args.save_dir)
+    if not ok:
+        logger.error("Failed to create post-intro save state.")
+        return 1
+
+    # Validate what we just created
+    if not args.skip_validation:
+        logger.info("\nValidating created save state...")
+        spec = SAVE_STATE_SPECS["s0_post_intro"]
+        state_path = os.path.join(args.save_dir, spec["filename"])
+        valid = validate_save_state(args.rom, state_path, spec)
+        if not valid:
+            logger.error("Post-creation validation FAILED!")
+            return 1
+        logger.info("Validation passed.")
+
+    logger.info("\nDone! Save states are ready for training.")
+    logger.info(f"  Use with: python scripts/train.py --rom {args.rom} "
+                f"--save-state {args.save_dir}/s0_post_intro.state")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_create_save_states.py
+++ b/tests/unit/test_create_save_states.py
@@ -1,0 +1,376 @@
+"""
+Unit tests for scripts/create_save_states.py.
+
+Tests CLI parsing, validation logic, and state creation flow
+using mocked PyBoy so no ROM is needed.
+"""
+
+import os
+import pytest
+from unittest.mock import Mock, patch, MagicMock, mock_open
+
+from scripts.create_save_states import (
+    build_parser,
+    validate_save_state,
+    validate_all,
+    create_post_intro_state,
+    SAVE_STATE_SPECS,
+    REDS_HOUSE_2F,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fixtures
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def save_dir(tmp_path):
+    """Provide a temporary save directory."""
+    d = tmp_path / "save_states"
+    d.mkdir()
+    return str(d)
+
+
+@pytest.fixture
+def fake_state_file(save_dir):
+    """Create a fake .state file with some content."""
+    path = os.path.join(save_dir, "s0_post_intro.state")
+    with open(path, "wb") as f:
+        f.write(b"\x00" * 1024)  # Fake state data
+    return path
+
+
+@pytest.fixture
+def mock_agent():
+    """Create a mock PokemonRedAgent."""
+    agent = MagicMock()
+    agent.memory = MagicMock()
+    agent.pyboy = MagicMock()
+    agent.load_save_state = Mock(return_value=True)
+    agent.save_save_state = Mock(return_value=True)
+    agent.run_opening_sequence = Mock(return_value=True)
+    agent.wait_frames = Mock()
+    return agent
+
+
+# ──────────────────────────────────────────────────────────────────────
+# CLI argument parsing
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestArgumentParser:
+    def test_requires_rom(self):
+        parser = build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args([])
+
+    def test_defaults(self):
+        parser = build_parser()
+        args = parser.parse_args(["--rom", "game.gb"])
+        assert args.rom == "game.gb"
+        assert args.save_dir == "save_states"
+        assert args.interactive is False
+        assert args.validate_only is False
+        assert args.skip_validation is False
+        assert args.save_name is None
+
+    def test_interactive_mode(self):
+        parser = build_parser()
+        args = parser.parse_args(["--rom", "game.gb", "--interactive"])
+        assert args.interactive is True
+
+    def test_validate_only(self):
+        parser = build_parser()
+        args = parser.parse_args(["--rom", "game.gb", "--validate-only"])
+        assert args.validate_only is True
+
+    def test_interactive_and_validate_mutually_exclusive(self):
+        parser = build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args([
+                "--rom", "game.gb",
+                "--interactive",
+                "--validate-only",
+            ])
+
+    def test_custom_save_dir(self):
+        parser = build_parser()
+        args = parser.parse_args(["--rom", "game.gb", "--save-dir", "/tmp/states"])
+        assert args.save_dir == "/tmp/states"
+
+    def test_save_name(self):
+        parser = build_parser()
+        args = parser.parse_args([
+            "--rom", "game.gb",
+            "--interactive",
+            "--save-name", "s2_pre_brock.state",
+        ])
+        assert args.save_name == "s2_pre_brock.state"
+
+    def test_skip_validation(self):
+        parser = build_parser()
+        args = parser.parse_args(["--rom", "game.gb", "--skip-validation"])
+        assert args.skip_validation is True
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Save state spec definitions
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestSaveStateSpecs:
+    def test_post_intro_spec_exists(self):
+        assert "s0_post_intro" in SAVE_STATE_SPECS
+
+    def test_all_specs_have_required_keys(self):
+        required = {"filename", "description", "expected_map_id", "expected_badges"}
+        for key, spec in SAVE_STATE_SPECS.items():
+            assert required.issubset(spec.keys()), f"Spec {key} missing keys"
+
+    def test_filenames_end_with_state(self):
+        for key, spec in SAVE_STATE_SPECS.items():
+            assert spec["filename"].endswith(".state"), (
+                f"Spec {key} filename should end with .state"
+            )
+
+    def test_post_intro_expects_player_bedroom(self):
+        spec = SAVE_STATE_SPECS["s0_post_intro"]
+        assert spec["expected_map_id"] == REDS_HOUSE_2F  # Player's bedroom
+        assert spec["expected_badges"] == 0
+
+    def test_post_brock_expects_boulder_badge(self):
+        spec = SAVE_STATE_SPECS["s3_post_brock"]
+        assert spec["expected_badges"] == 0x01  # Boulder badge
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Validation
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestValidation:
+    def test_missing_file_returns_false(self, save_dir):
+        spec = SAVE_STATE_SPECS["s0_post_intro"]
+        result = validate_save_state(
+            "game.gb",
+            os.path.join(save_dir, "nonexistent.state"),
+            spec,
+        )
+        assert result is False
+
+    def test_empty_file_returns_false(self, save_dir):
+        path = os.path.join(save_dir, "empty.state")
+        with open(path, "wb") as f:
+            pass  # 0 bytes
+
+        spec = SAVE_STATE_SPECS["s0_post_intro"]
+        result = validate_save_state("game.gb", path, spec)
+        assert result is False
+
+    @patch("scripts.create_save_states.PokemonRedAgent")
+    def test_valid_post_intro_passes(self, MockAgent, fake_state_file):
+        agent = MagicMock()
+        MockAgent.return_value = agent
+
+        agent.load_save_state.return_value = True
+        # Map ID 1 = Pallet Town, position (5, 3)
+        agent.memory.__getitem__ = lambda self, addr: {
+            0xD35E: REDS_HOUSE_2F,  # map_id = Player's bedroom
+            0xD362: 9,    # player_x
+            0xD361: 4,    # player_y
+            0xD18C: 0,    # level (no Pokemon yet)
+            0xD16C: 0,    # current_hp_low
+            0xD16D: 0,    # current_hp_high
+            0xD16E: 0,    # max_hp_low
+            0xD16F: 0,    # max_hp_high
+            0xD356: 0,    # badges = 0
+            0xD163: 0,    # party_count = 0
+        }.get(addr, 0)
+
+        spec = SAVE_STATE_SPECS["s0_post_intro"]
+        result = validate_save_state("game.gb", fake_state_file, spec)
+        assert result is True
+
+    @patch("scripts.create_save_states.PokemonRedAgent")
+    def test_wrong_map_fails(self, MockAgent, fake_state_file):
+        agent = MagicMock()
+        MockAgent.return_value = agent
+
+        agent.load_save_state.return_value = True
+        # Map ID 3 = Pewter City (wrong for post-intro)
+        agent.memory.__getitem__ = lambda self, addr: {
+            0xD35E: 3,    # map_id = Pewter (wrong!)
+            0xD362: 5,
+            0xD361: 3,
+            0xD18C: 5,
+            0xD16C: 20,
+            0xD16D: 0,
+            0xD16E: 20,
+            0xD16F: 0,
+            0xD356: 0,
+            0xD163: 0,
+        }.get(addr, 0)
+
+        spec = SAVE_STATE_SPECS["s0_post_intro"]
+        result = validate_save_state("game.gb", fake_state_file, spec)
+        assert result is False
+
+    @patch("scripts.create_save_states.PokemonRedAgent")
+    def test_load_failure_returns_false(self, MockAgent, fake_state_file):
+        agent = MagicMock()
+        MockAgent.return_value = agent
+        agent.load_save_state.return_value = False
+
+        spec = SAVE_STATE_SPECS["s0_post_intro"]
+        result = validate_save_state("game.gb", fake_state_file, spec)
+        assert result is False
+
+    @patch("scripts.create_save_states.PokemonRedAgent")
+    def test_agent_exception_returns_false(self, MockAgent, fake_state_file):
+        MockAgent.side_effect = RuntimeError("PyBoy init failed")
+
+        spec = SAVE_STATE_SPECS["s0_post_intro"]
+        result = validate_save_state("game.gb", fake_state_file, spec)
+        assert result is False
+
+    @patch("scripts.create_save_states.PokemonRedAgent")
+    def test_pyboy_stop_called_on_cleanup(self, MockAgent, fake_state_file):
+        agent = MagicMock()
+        MockAgent.return_value = agent
+        agent.load_save_state.return_value = True
+        agent.memory.__getitem__ = lambda self, addr: {
+            0xD35E: REDS_HOUSE_2F, 0xD362: 9, 0xD361: 4,
+            0xD18C: 0, 0xD16C: 0, 0xD16D: 0,
+            0xD16E: 0, 0xD16F: 0, 0xD356: 0, 0xD163: 0,
+        }.get(addr, 0)
+
+        spec = SAVE_STATE_SPECS["s0_post_intro"]
+        validate_save_state("game.gb", fake_state_file, spec)
+        agent.pyboy.stop.assert_called_once()
+
+
+class TestValidateAll:
+    @patch("scripts.create_save_states.validate_save_state")
+    def test_skips_missing_files(self, mock_validate, save_dir):
+        results = validate_all("game.gb", save_dir)
+        # No files exist, so all should be None
+        for val in results.values():
+            assert val is None
+        mock_validate.assert_not_called()
+
+    @patch("scripts.create_save_states.validate_save_state", return_value=True)
+    def test_validates_existing_files(self, mock_validate, fake_state_file, save_dir):
+        results = validate_all("game.gb", save_dir)
+        assert results["s0_post_intro"] is True
+        mock_validate.assert_called_once()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# State creation
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestCreatePostIntro:
+    @patch("scripts.create_save_states.PokemonRedAgent")
+    @patch("scripts.create_save_states.read_player_position")
+    @patch("scripts.create_save_states.read_player_stats")
+    def test_creates_state_on_success(
+        self, mock_stats, mock_pos, MockAgent, save_dir
+    ):
+        agent = MagicMock()
+        MockAgent.return_value = agent
+
+        agent.run_opening_sequence.return_value = True
+        agent.save_save_state.return_value = True
+        mock_pos.return_value = {"map": REDS_HOUSE_2F, "x": 9, "y": 4}
+        mock_stats.return_value = {
+            "party_count": 0, "badges": 0, "level": 0,
+            "current_hp": 0, "max_hp": 0, "hp_ratio": 0,
+        }
+
+        result = create_post_intro_state("game.gb", save_dir)
+        assert result is True
+        agent.run_opening_sequence.assert_called_once()
+        agent.save_save_state.assert_called_once()
+
+    @patch("scripts.create_save_states.PokemonRedAgent")
+    def test_fails_when_opening_fails(self, MockAgent, save_dir):
+        agent = MagicMock()
+        MockAgent.return_value = agent
+        agent.run_opening_sequence.return_value = False
+
+        result = create_post_intro_state("game.gb", save_dir)
+        assert result is False
+        agent.save_save_state.assert_not_called()
+
+    @patch("scripts.create_save_states.PokemonRedAgent")
+    @patch("scripts.create_save_states.read_player_position")
+    @patch("scripts.create_save_states.read_player_stats")
+    def test_fails_when_map_id_zero(
+        self, mock_stats, mock_pos, MockAgent, save_dir
+    ):
+        agent = MagicMock()
+        MockAgent.return_value = agent
+        agent.run_opening_sequence.return_value = True
+        mock_pos.return_value = {"map": 0, "x": 0, "y": 0}
+        mock_stats.return_value = {
+            "party_count": 0, "badges": 0, "level": 0,
+            "current_hp": 0, "max_hp": 0, "hp_ratio": 0,
+        }
+
+        result = create_post_intro_state("game.gb", save_dir)
+        assert result is False
+
+    @patch("scripts.create_save_states.PokemonRedAgent")
+    @patch("scripts.create_save_states.read_player_position")
+    @patch("scripts.create_save_states.read_player_stats")
+    def test_fails_when_save_fails(
+        self, mock_stats, mock_pos, MockAgent, save_dir
+    ):
+        agent = MagicMock()
+        MockAgent.return_value = agent
+        agent.run_opening_sequence.return_value = True
+        agent.save_save_state.return_value = False
+        mock_pos.return_value = {"map": REDS_HOUSE_2F, "x": 9, "y": 4}
+        mock_stats.return_value = {
+            "party_count": 0, "badges": 0, "level": 0,
+            "current_hp": 0, "max_hp": 0, "hp_ratio": 0,
+        }
+
+        result = create_post_intro_state("game.gb", save_dir)
+        assert result is False
+
+    @patch("scripts.create_save_states.PokemonRedAgent")
+    def test_pyboy_cleaned_up_on_failure(self, MockAgent, save_dir):
+        agent = MagicMock()
+        MockAgent.return_value = agent
+        agent.run_opening_sequence.side_effect = RuntimeError("boom")
+
+        create_post_intro_state("game.gb", save_dir)
+        agent.pyboy.stop.assert_called_once()
+
+    @patch("scripts.create_save_states.PokemonRedAgent")
+    @patch("scripts.create_save_states.read_player_position")
+    @patch("scripts.create_save_states.read_player_stats")
+    def test_saves_to_correct_path(
+        self, mock_stats, mock_pos, MockAgent, save_dir
+    ):
+        agent = MagicMock()
+        MockAgent.return_value = agent
+        agent.run_opening_sequence.return_value = True
+        agent.save_save_state.return_value = True
+        mock_pos.return_value = {"map": REDS_HOUSE_2F, "x": 9, "y": 4}
+        mock_stats.return_value = {
+            "party_count": 0, "badges": 0, "level": 0,
+            "current_hp": 0, "max_hp": 0, "hp_ratio": 0,
+        }
+
+        create_post_intro_state("game.gb", save_dir)
+
+        expected_path = os.path.join(save_dir, "s0_post_intro.state")
+        agent.save_save_state.assert_called_once_with(expected_path)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Adds `scripts/create_save_states.py` — automates Pokemon Red's opening sequence and saves PyBoy `.state` files for fast episode resets during RL training
- The post-intro save state (`s0_post_intro.state`) eliminates the ~10s intro replay on every episode reset, critical for training throughput
- Supports 3 modes: **automatic** (creates post-intro state), **interactive** (play and Ctrl+C to save), and **validate-only** (verify existing states)
- Defines validation specs for 4 curriculum checkpoints: post-intro, post-starter, pre-Brock, post-Brock
- Adds `*.state` to `.gitignore` (binary files containing ROM data)
- 28 new unit tests (mocked PyBoy), 512 total passing

## Test plan
- [x] `python scripts/create_save_states.py --rom PokemonRed.gb -vv` — creates and validates `s0_post_intro.state` (167KB, 1.5s)
- [x] `--validate-only` mode confirms existing state passes all checks
- [x] 28 unit tests cover parser, spec definitions, validation logic (map/badge/party checks), creation flow, error handling, and cleanup
- [x] Full test suite: 512 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)