### PR TITLE
Add paper observation treatments: pixel, symbolic, hybrid (AMC-59/60/61)

### DIFF
--- a/pokemon_red_ai/cli/commands.py
+++ b/pokemon_red_ai/cli/commands.py
@@ -130,7 +130,7 @@ def main(ctx):
 @click.option('--reward-strategy', default='events', help='Reward strategy (events = event-flag milestones)',
               type=click.Choice(['standard', 'exploration', 'progress', 'sparse', 'events']))
 @click.option('--observation-type', default='multi_modal', help='Observation type',
-              type=click.Choice(['multi_modal', 'screen_only', 'minimal']))
+              type=click.Choice(['multi_modal', 'screen_only', 'minimal', 'pixel', 'symbolic', 'hybrid']))
 @click.option('--show-game/--no-show-game', default=False, help='Show game window during training')
 @click.option('--show-plots/--no-show-plots', default=False, help='Show live training plots')
 @click.option('--monitor-mode', is_flag=True, help='Enable monitoring (game + plots)')

--- a/pokemon_red_ai/environment/__init__.py
+++ b/pokemon_red_ai/environment/__init__.py
@@ -25,7 +25,16 @@ from .observations import (
     get_screen_features,
     create_minimal_observation_space,
     process_minimal_observation,
-    preprocess_screen_for_cnn
+    preprocess_screen_for_cnn,
+    # Paper observation treatments
+    NUM_EVENT_FLAGS,
+    SYMBOLIC_DIM,
+    create_pixel_observation_space,
+    process_pixel_observation,
+    create_symbolic_observation_space,
+    process_symbolic_observation,
+    create_hybrid_observation_space,
+    process_hybrid_observation,
 )
 
 __all__ = [
@@ -53,4 +62,14 @@ __all__ = [
     "create_minimal_observation_space",
     "process_minimal_observation",
     "preprocess_screen_for_cnn",
+
+    # Paper observation treatments
+    "NUM_EVENT_FLAGS",
+    "SYMBOLIC_DIM",
+    "create_pixel_observation_space",
+    "process_pixel_observation",
+    "create_symbolic_observation_space",
+    "process_symbolic_observation",
+    "create_hybrid_observation_space",
+    "process_hybrid_observation",
 ]

--- a/pokemon_red_ai/environment/gym_env.py
+++ b/pokemon_red_ai/environment/gym_env.py
@@ -14,7 +14,15 @@ from ..game.agent import PokemonRedAgent
 from .observations import (
     create_observation_space,
     process_game_state,
-    validate_observation
+    validate_observation,
+    # Paper observation treatments
+    create_pixel_observation_space,
+    process_pixel_observation,
+    create_symbolic_observation_space,
+    process_symbolic_observation,
+    create_hybrid_observation_space,
+    process_hybrid_observation,
+    SYMBOLIC_DIM,
 )
 from .rewards import (
     create_reward_calculator,
@@ -115,6 +123,13 @@ class PokemonRedGymEnv(gym.Env):
                 shape=(screen_size[1], screen_size[0], 3),  # (H, W, C)
                 dtype=np.uint8
             )
+        # ── Paper observation treatments ────────────────────────────
+        elif observation_type == "pixel":
+            self.observation_space = create_pixel_observation_space(screen_size)
+        elif observation_type == "symbolic":
+            self.observation_space = create_symbolic_observation_space()
+        elif observation_type == "hybrid":
+            self.observation_space = create_hybrid_observation_space(screen_size)
         else:
             raise ValueError(f"Unknown observation type: {observation_type}")
 
@@ -161,6 +176,20 @@ class PokemonRedGymEnv(gym.Env):
             screen = self.game.get_screen_array()
             screen = downsample_screen(screen, self.screen_size)
             return normalize_screen(screen)
+        # ── Paper observation treatments ────────────────────────────
+        elif self.observation_type == "pixel":
+            return process_pixel_observation(self.game, self.screen_size)
+        elif self.observation_type == "symbolic":
+            return process_symbolic_observation(
+                self.game, self.episode_steps,
+                self.max_episode_steps, self.visited_locations
+            )
+        elif self.observation_type == "hybrid":
+            return process_hybrid_observation(
+                self.game, self.episode_steps,
+                self.max_episode_steps, self.visited_locations,
+                self.screen_size
+            )
 
     def _calculate_reward(self) -> float:
         """Calculate reward for current state."""
@@ -451,6 +480,16 @@ class PokemonRedGymEnv(gym.Env):
             return np.zeros(11, dtype=np.uint16)
         elif self.observation_type == "screen_only":
             return np.zeros((self.screen_size[1], self.screen_size[0], 3), dtype=np.uint8)
+        # ── Paper observation treatments ────────────────────────────
+        elif self.observation_type == "pixel":
+            return np.zeros((self.screen_size[1], self.screen_size[0], 1), dtype=np.uint8)
+        elif self.observation_type == "symbolic":
+            return np.zeros(SYMBOLIC_DIM, dtype=np.float32)
+        elif self.observation_type == "hybrid":
+            return {
+                "screen": np.zeros((self.screen_size[1], self.screen_size[0], 1), dtype=np.uint8),
+                "game_state": np.zeros(SYMBOLIC_DIM, dtype=np.float32),
+            }
 
     def get_action_meanings(self) -> list:
         """Get human-readable action meanings."""

--- a/pokemon_red_ai/environment/observations.py
+++ b/pokemon_red_ai/environment/observations.py
@@ -304,6 +304,243 @@ def validate_observation(observation: Dict[str, np.ndarray],
         return False
 
 
+# ──────────────────────────────────────────────────────────────────────
+# Paper observation treatments (pixel / symbolic / hybrid)
+# ──────────────────────────────────────────────────────────────────────
+
+# Number of pre-registered event flags tracked in event_flags.py
+NUM_EVENT_FLAGS = 18
+# Symbolic vector layout: position(3) + stats(6) + event_flags(18) + exploration(2) = 29
+SYMBOLIC_DIM = 3 + 6 + NUM_EVENT_FLAGS + 2
+
+
+def _screen_to_grayscale(screen: np.ndarray) -> np.ndarray:
+    """Convert a screen array to single-channel grayscale uint8."""
+    if len(screen.shape) == 3 and screen.shape[2] >= 3:
+        # Luminance weights: 0.299R + 0.587G + 0.114B
+        gray = np.dot(screen[:, :, :3], [0.299, 0.587, 0.114])
+        return gray.astype(np.uint8)
+    elif len(screen.shape) == 3 and screen.shape[2] == 1:
+        return screen.astype(np.uint8)
+    elif len(screen.shape) == 2:
+        return screen.astype(np.uint8)[..., np.newaxis]
+    # Fallback
+    return screen.astype(np.uint8)
+
+
+def create_pixel_observation_space(
+    screen_size: Tuple[int, int] = (80, 72),
+) -> spaces.Box:
+    """
+    Observation space for the **pixel** treatment.
+
+    Single-channel grayscale screen (H, W, 1).  Intended for use with
+    SB3's ``CnnPolicy`` / ``CnnLstmPolicy`` which expect image-shaped
+    ``Box`` spaces.
+
+    This is Treatment 1 in the paper's 3-treatment experimental design.
+    """
+    width, height = screen_size
+    return spaces.Box(
+        low=0, high=255,
+        shape=(height, width, 1),
+        dtype=np.uint8,
+    )
+
+
+def process_pixel_observation(
+    agent,
+    screen_size: Tuple[int, int] = (80, 72),
+) -> np.ndarray:
+    """
+    Build the **pixel** observation: 80x72x1 grayscale screen.
+
+    Args:
+        agent: PokemonRedAgent instance.
+        screen_size: Target (width, height) for downsampling.
+
+    Returns:
+        ``np.ndarray`` of shape ``(H, W, 1)`` with dtype ``uint8``.
+    """
+    raw = agent.get_screen_array()
+    small = downsample_screen(raw, screen_size)
+    gray = _screen_to_grayscale(small)
+    if len(gray.shape) == 2:
+        gray = gray[..., np.newaxis]
+    return gray
+
+
+def create_symbolic_observation_space() -> spaces.Box:
+    """
+    Observation space for the **symbolic** treatment.
+
+    A flat ``float32`` vector containing only structured game-state
+    features read from memory — no pixel data at all.  Intended for
+    use with SB3's ``MlpPolicy`` / ``MlpLstmPolicy``.
+
+    Layout (29 features total):
+        - position: x, y, map_id  (3)
+        - stats: level, hp_ratio, badges_bitfield, party_count,
+                 episode_progress, badge_count  (6)
+        - event_flags: 18 binary flags  (18)
+        - exploration: locations_visited, unique_maps  (2)
+
+    This is Treatment 2 in the paper's 3-treatment experimental design.
+    """
+    return spaces.Box(
+        low=0.0, high=1.0,
+        shape=(SYMBOLIC_DIM,),
+        dtype=np.float32,
+    )
+
+
+def _build_symbolic_vector(
+    agent,
+    episode_steps: int,
+    max_episode_steps: int,
+    visited_locations: set,
+) -> np.ndarray:
+    """
+    Build the normalised symbolic feature vector (shared by symbolic
+    and hybrid treatments).
+
+    All values are normalised to [0, 1] for stable MLP training.
+    """
+    position = agent.get_player_position()
+    stats = agent.get_player_stats()
+
+    hp_ratio = stats['current_hp'] / max(stats['max_hp'], 1)
+    episode_progress = episode_steps / max(max_episode_steps, 1)
+    badge_count = bin(stats['badges']).count('1')
+
+    unique_maps = set()
+    for x, y, map_id in visited_locations:
+        if map_id != 0:
+            unique_maps.add(map_id)
+
+    # Event flags (18 binary features)
+    event_flag_values = np.zeros(NUM_EVENT_FLAGS, dtype=np.float32)
+    try:
+        from ..game.event_flags import read_boulder_path_flags
+        flags = read_boulder_path_flags(agent.memory)
+        for i, val in enumerate(flags.values()):
+            if i < NUM_EVENT_FLAGS:
+                event_flag_values[i] = 1.0 if val else 0.0
+    except Exception:
+        pass  # Graceful fallback — zeros if flags unavailable
+
+    vec = np.concatenate([
+        # Position (3) — normalised to [0, 1]
+        np.array([
+            position['x'] / 255.0,
+            position['y'] / 255.0,
+            position['map'] / 255.0,
+        ], dtype=np.float32),
+        # Stats (6)
+        np.array([
+            min(stats['level'], 100) / 100.0,
+            float(np.clip(hp_ratio, 0, 1)),
+            stats['badges'] / 255.0,
+            stats['party_count'] / 6.0,
+            float(np.clip(episode_progress, 0, 1)),
+            badge_count / 8.0,
+        ], dtype=np.float32),
+        # Event flags (18)
+        event_flag_values,
+        # Exploration (2)
+        np.array([
+            min(len(visited_locations), 10000) / 10000.0,
+            min(len(unique_maps), 50) / 50.0,
+        ], dtype=np.float32),
+    ])
+
+    return vec
+
+
+def process_symbolic_observation(
+    agent,
+    episode_steps: int,
+    max_episode_steps: int,
+    visited_locations: set,
+) -> np.ndarray:
+    """
+    Build the **symbolic** observation: flat float32 vector.
+
+    Args:
+        agent: PokemonRedAgent instance.
+        episode_steps: Current step in the episode.
+        max_episode_steps: Max steps before truncation.
+        visited_locations: Set of (x, y, map) tuples visited so far.
+
+    Returns:
+        ``np.ndarray`` of shape ``(SYMBOLIC_DIM,)`` with dtype ``float32``.
+    """
+    return _build_symbolic_vector(
+        agent, episode_steps, max_episode_steps, visited_locations
+    )
+
+
+def create_hybrid_observation_space(
+    screen_size: Tuple[int, int] = (80, 72),
+) -> spaces.Dict:
+    """
+    Observation space for the **hybrid** treatment.
+
+    A ``Dict`` space with two keys:
+
+    - ``"screen"``: grayscale image ``(H, W, 1)`` processed by a CNN.
+    - ``"game_state"``: flat ``float32`` vector processed by an MLP.
+
+    The two feature streams are concatenated after extraction by
+    SB3's ``MultiInputPolicy`` / ``MultiInputLstmPolicy``.
+
+    This is Treatment 3 in the paper's 3-treatment experimental design.
+    """
+    width, height = screen_size
+    return spaces.Dict({
+        "screen": spaces.Box(
+            low=0, high=255,
+            shape=(height, width, 1),
+            dtype=np.uint8,
+        ),
+        "game_state": spaces.Box(
+            low=0.0, high=1.0,
+            shape=(SYMBOLIC_DIM,),
+            dtype=np.float32,
+        ),
+    })
+
+
+def process_hybrid_observation(
+    agent,
+    episode_steps: int,
+    max_episode_steps: int,
+    visited_locations: set,
+    screen_size: Tuple[int, int] = (80, 72),
+) -> Dict[str, np.ndarray]:
+    """
+    Build the **hybrid** observation: grayscale screen + symbolic vector.
+
+    Args:
+        agent: PokemonRedAgent instance.
+        episode_steps: Current step in the episode.
+        max_episode_steps: Max steps before truncation.
+        visited_locations: Set of (x, y, map) tuples visited so far.
+        screen_size: Target (width, height) for downsampling.
+
+    Returns:
+        Dict with ``"screen"`` and ``"game_state"`` arrays.
+    """
+    screen = process_pixel_observation(agent, screen_size)
+    game_state = _build_symbolic_vector(
+        agent, episode_steps, max_episode_steps, visited_locations
+    )
+    return {
+        "screen": screen,
+        "game_state": game_state,
+    }
+
+
 def preprocess_screen_for_cnn(screen: np.ndarray, normalize: bool = True) -> np.ndarray:
     """
     Preprocess screen specifically for CNN training.

--- a/pokemon_red_ai/training/__init__.py
+++ b/pokemon_red_ai/training/__init__.py
@@ -26,6 +26,7 @@ from .models import (
     create_model,
     get_model_config,
     get_policy_kwargs_for_observation_type,
+    get_policy_type_for_observation,
     PokemonFeaturesExtractor,
     optimize_hyperparameters
 )
@@ -49,6 +50,7 @@ __all__ = [
     "create_model",
     "get_model_config",
     "get_policy_kwargs_for_observation_type",
+    "get_policy_type_for_observation",
     "PokemonFeaturesExtractor",
     "optimize_hyperparameters",
 ]

--- a/pokemon_red_ai/training/models.py
+++ b/pokemon_red_ai/training/models.py
@@ -455,7 +455,8 @@ def get_policy_kwargs_for_observation_type(observation_type: str) -> Dict[str, A
     Get appropriate policy kwargs based on observation type.
 
     Args:
-        observation_type: Type of observation ('multi_modal', 'minimal', 'screen_only')
+        observation_type: Type of observation ('multi_modal', 'minimal',
+            'screen_only', 'pixel', 'symbolic', 'hybrid')
 
     Returns:
         Policy kwargs dictionary
@@ -477,9 +478,66 @@ def get_policy_kwargs_for_observation_type(observation_type: str) -> Dict[str, A
             'net_arch': dict(pi=[128, 64], vf=[128, 64]),  # Fixed: use dict
             'activation_fn': nn.ReLU
         }
+    # ── Paper observation treatments ────────────────────────────────
+    elif observation_type == "pixel":
+        # SB3's NatureCNN auto-applies for Box image spaces
+        return {
+            'net_arch': dict(pi=[256, 128], vf=[256, 128]),
+            'activation_fn': nn.ReLU,
+        }
+    elif observation_type == "symbolic":
+        return {
+            'net_arch': dict(pi=[256, 128], vf=[256, 128]),
+            'activation_fn': nn.ReLU,
+        }
+    elif observation_type == "hybrid":
+        # SB3's CombinedExtractor auto-applies for Dict spaces
+        # with mixed image + vector keys
+        return {
+            'net_arch': dict(pi=[256, 128], vf=[256, 128]),
+            'activation_fn': nn.ReLU,
+        }
     else:
         logger.warning(f"Unknown observation type: {observation_type}, using default")
         return {}
+
+
+def get_policy_type_for_observation(
+    observation_type: str,
+    algorithm: str = "PPO",
+) -> str:
+    """
+    Return the correct SB3 policy string for a given observation type
+    and algorithm combination.
+
+    Args:
+        observation_type: One of 'pixel', 'symbolic', 'hybrid',
+            'multi_modal', 'screen_only', 'minimal'.
+        algorithm: 'PPO' or 'RecurrentPPO'.
+
+    Returns:
+        Policy class name string (e.g. 'CnnPolicy', 'MlpLstmPolicy').
+    """
+    # Map observation type → (PPO policy, RecurrentPPO policy)
+    policy_map = {
+        # Paper treatments
+        "pixel":       ("CnnPolicy",        "CnnLstmPolicy"),
+        "symbolic":    ("MlpPolicy",        "MlpLstmPolicy"),
+        "hybrid":      ("MultiInputPolicy", "MultiInputLstmPolicy"),
+        # Legacy types
+        "multi_modal": ("MultiInputPolicy", "MultiInputLstmPolicy"),
+        "screen_only": ("CnnPolicy",        "CnnLstmPolicy"),
+        "minimal":     ("MlpPolicy",        "MlpLstmPolicy"),
+    }
+
+    if observation_type not in policy_map:
+        raise ValueError(
+            f"Unknown observation type: {observation_type}. "
+            f"Valid types: {list(policy_map.keys())}"
+        )
+
+    ppo_policy, rppo_policy = policy_map[observation_type]
+    return rppo_policy if algorithm == "RecurrentPPO" else ppo_policy
 
 
 def optimize_hyperparameters(env: gym.Env,

--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -458,7 +458,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--observation-type", type=str, default="multi_modal",
-        choices=["multi_modal", "screen_only", "minimal"],
+        choices=["multi_modal", "screen_only", "minimal", "pixel", "symbolic", "hybrid"],
         help="Observation representation.",
     )
     p.add_argument(

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -84,7 +84,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--observation-type", type=str, default="multi_modal",
-        choices=["multi_modal", "screen_only", "minimal"],
+        choices=["multi_modal", "screen_only", "minimal", "pixel", "symbolic", "hybrid"],
         help="Observation representation.",
     )
     p.add_argument(

--- a/tests/unit/environment/conftest.py
+++ b/tests/unit/environment/conftest.py
@@ -345,7 +345,7 @@ def reward_strategy(request):
     return request.param
 
 
-@pytest.fixture(params=['multi_modal', 'minimal', 'screen_only'])
+@pytest.fixture(params=['multi_modal', 'minimal', 'screen_only', 'pixel', 'symbolic', 'hybrid'])
 def observation_type(request):
     """Parameterized fixture for testing all observation types."""
     return request.param

--- a/tests/unit/environment/test_observations.py
+++ b/tests/unit/environment/test_observations.py
@@ -18,7 +18,18 @@ from pokemon_red_ai.environment.observations import (
     create_minimal_observation_space,
     process_minimal_observation,
     validate_observation,
-    preprocess_screen_for_cnn
+    preprocess_screen_for_cnn,
+    # Paper observation treatments
+    NUM_EVENT_FLAGS,
+    SYMBOLIC_DIM,
+    _screen_to_grayscale,
+    create_pixel_observation_space,
+    process_pixel_observation,
+    create_symbolic_observation_space,
+    _build_symbolic_vector,
+    process_symbolic_observation,
+    create_hybrid_observation_space,
+    process_hybrid_observation,
 )
 
 
@@ -673,6 +684,377 @@ class TestObservationPerformance:
 
         result = benchmark_runner.run('downsample', downsample_op, iterations=1000)
         assert result['mean'] < 0.005  # Should be under 5ms
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Paper observation treatments: pixel / symbolic / hybrid
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestConstants:
+    """Test paper observation constants."""
+
+    def test_num_event_flags(self):
+        """NUM_EVENT_FLAGS matches the 18 pre-registered boulder path flags."""
+        assert NUM_EVENT_FLAGS == 18
+
+    def test_symbolic_dim(self):
+        """SYMBOLIC_DIM = position(3) + stats(6) + flags(18) + exploration(2) = 29."""
+        assert SYMBOLIC_DIM == 29
+        assert SYMBOLIC_DIM == 3 + 6 + NUM_EVENT_FLAGS + 2
+
+
+class TestScreenToGrayscale:
+    """Test the _screen_to_grayscale helper."""
+
+    def test_rgb_to_grayscale(self):
+        """Convert a 3-channel RGB image to single-channel grayscale."""
+        screen = np.random.randint(0, 255, (72, 80, 3), dtype=np.uint8)
+        gray = _screen_to_grayscale(screen)
+
+        assert gray.dtype == np.uint8
+        # Result should be 2D or have a trailing channel dim
+        assert gray.shape[0] == 72
+        assert gray.shape[1] == 80
+
+    def test_rgba_to_grayscale(self):
+        """Convert a 4-channel RGBA image (drops alpha) to grayscale."""
+        screen = np.random.randint(0, 255, (72, 80, 4), dtype=np.uint8)
+        gray = _screen_to_grayscale(screen)
+
+        assert gray.dtype == np.uint8
+        assert gray.shape[0] == 72
+        assert gray.shape[1] == 80
+
+    def test_single_channel_passthrough(self):
+        """Single-channel input is returned as uint8."""
+        screen = np.random.randint(0, 255, (72, 80, 1), dtype=np.uint8)
+        gray = _screen_to_grayscale(screen)
+
+        assert gray.dtype == np.uint8
+        assert gray.shape == (72, 80, 1)
+
+    def test_grayscale_2d_input(self):
+        """2D grayscale input gets a trailing channel dim."""
+        screen = np.random.randint(0, 255, (72, 80), dtype=np.uint8)
+        gray = _screen_to_grayscale(screen)
+
+        assert gray.dtype == np.uint8
+        assert gray.shape == (72, 80, 1)
+
+
+class TestPixelObservation:
+    """Test pixel observation space and processing (Treatment 1)."""
+
+    def test_create_pixel_space_default(self):
+        """Default pixel space is Box(72, 80, 1, uint8)."""
+        space = create_pixel_observation_space()
+
+        assert isinstance(space, gym.spaces.Box)
+        assert space.shape == (72, 80, 1)
+        assert space.dtype == np.uint8
+        assert space.low.min() == 0
+        assert space.high.max() == 255
+
+    def test_create_pixel_space_custom_size(self):
+        """Pixel space respects custom screen_size."""
+        space = create_pixel_observation_space(screen_size=(40, 36))
+
+        assert space.shape == (36, 40, 1)
+
+    def test_process_pixel_observation_shape(self):
+        """process_pixel_observation returns (H, W, 1) uint8."""
+        agent = Mock()
+        agent.get_screen_array = Mock(
+            return_value=np.random.randint(0, 255, (144, 160, 3), dtype=np.uint8)
+        )
+
+        obs = process_pixel_observation(agent)
+
+        assert isinstance(obs, np.ndarray)
+        assert obs.shape == (72, 80, 1)
+        assert obs.dtype == np.uint8
+
+    def test_pixel_observation_in_space(self):
+        """Pixel observation is contained in its observation space."""
+        agent = Mock()
+        agent.get_screen_array = Mock(
+            return_value=np.random.randint(0, 255, (144, 160, 3), dtype=np.uint8)
+        )
+
+        space = create_pixel_observation_space()
+        obs = process_pixel_observation(agent)
+
+        assert space.contains(obs)
+
+
+class TestSymbolicObservation:
+    """Test symbolic observation space and processing (Treatment 2)."""
+
+    @pytest.fixture
+    def mock_agent(self):
+        """Create a mock agent with standard game state."""
+        agent = Mock()
+        agent.get_player_position = Mock(return_value={'x': 10, 'y': 20, 'map': 3})
+        agent.get_player_stats = Mock(return_value={
+            'level': 15,
+            'current_hp': 40,
+            'max_hp': 50,
+            'badges': 1,
+            'party_count': 3,
+        })
+        agent.memory = Mock()
+        return agent
+
+    def test_create_symbolic_space(self):
+        """Symbolic space is Box(29, float32, [0, 1])."""
+        space = create_symbolic_observation_space()
+
+        assert isinstance(space, gym.spaces.Box)
+        assert space.shape == (SYMBOLIC_DIM,)
+        assert space.dtype == np.float32
+        assert space.low.min() == 0.0
+        assert space.high.max() == 1.0
+
+    @patch("pokemon_red_ai.game.event_flags.read_boulder_path_flags")
+    def test_process_symbolic_observation_shape(self, mock_flags, mock_agent):
+        """process_symbolic_observation returns float32 vector of length 29."""
+        mock_flags.return_value = {f"flag_{i}": False for i in range(18)}
+
+        obs = process_symbolic_observation(
+            mock_agent,
+            episode_steps=500,
+            max_episode_steps=1000,
+            visited_locations={(1, 2, 1), (3, 4, 2)},
+        )
+
+        assert isinstance(obs, np.ndarray)
+        assert obs.shape == (SYMBOLIC_DIM,)
+        assert obs.dtype == np.float32
+
+    @patch("pokemon_red_ai.game.event_flags.read_boulder_path_flags")
+    def test_symbolic_values_normalized(self, mock_flags, mock_agent):
+        """All symbolic vector values are in [0, 1]."""
+        mock_flags.return_value = {f"flag_{i}": (i % 3 == 0) for i in range(18)}
+
+        obs = process_symbolic_observation(
+            mock_agent,
+            episode_steps=500,
+            max_episode_steps=1000,
+            visited_locations={(1, 2, 1)},
+        )
+
+        assert obs.min() >= 0.0, f"min value {obs.min()} < 0"
+        assert obs.max() <= 1.0, f"max value {obs.max()} > 1"
+
+    @patch("pokemon_red_ai.game.event_flags.read_boulder_path_flags")
+    def test_symbolic_position_encoding(self, mock_flags, mock_agent):
+        """Position fields are x/255, y/255, map/255."""
+        mock_flags.return_value = {f"flag_{i}": False for i in range(18)}
+
+        obs = process_symbolic_observation(
+            mock_agent,
+            episode_steps=0,
+            max_episode_steps=1000,
+            visited_locations=set(),
+        )
+
+        assert np.isclose(obs[0], 10 / 255.0)   # x
+        assert np.isclose(obs[1], 20 / 255.0)   # y
+        assert np.isclose(obs[2], 3 / 255.0)    # map
+
+    @patch("pokemon_red_ai.game.event_flags.read_boulder_path_flags")
+    def test_symbolic_stats_encoding(self, mock_flags, mock_agent):
+        """Stats fields are correctly normalised."""
+        mock_flags.return_value = {f"flag_{i}": False for i in range(18)}
+
+        obs = process_symbolic_observation(
+            mock_agent,
+            episode_steps=500,
+            max_episode_steps=1000,
+            visited_locations=set(),
+        )
+
+        # level=15 → 15/100
+        assert np.isclose(obs[3], 15 / 100.0)
+        # hp_ratio = 40/50 = 0.8
+        assert np.isclose(obs[4], 0.8)
+        # badges=1 → 1/255
+        assert np.isclose(obs[5], 1 / 255.0)
+        # party_count=3 → 3/6
+        assert np.isclose(obs[6], 3 / 6.0)
+        # episode_progress = 500/1000 = 0.5
+        assert np.isclose(obs[7], 0.5)
+        # badge_count=1 → 1/8
+        assert np.isclose(obs[8], 1 / 8.0)
+
+    @patch("pokemon_red_ai.game.event_flags.read_boulder_path_flags")
+    def test_symbolic_event_flags(self, mock_flags, mock_agent):
+        """Event flag bits are 0.0 or 1.0 in the vector."""
+        flags = {f"flag_{i}": (i < 5) for i in range(18)}  # first 5 set
+        mock_flags.return_value = flags
+
+        obs = process_symbolic_observation(
+            mock_agent,
+            episode_steps=0,
+            max_episode_steps=1000,
+            visited_locations=set(),
+        )
+
+        flag_start = 9  # position(3) + stats(6)
+        for i in range(18):
+            expected = 1.0 if i < 5 else 0.0
+            assert obs[flag_start + i] == expected, f"Flag {i}: expected {expected}, got {obs[flag_start + i]}"
+
+    @patch("pokemon_red_ai.game.event_flags.read_boulder_path_flags")
+    def test_symbolic_observation_in_space(self, mock_flags, mock_agent):
+        """Symbolic observation is contained in its observation space."""
+        mock_flags.return_value = {f"flag_{i}": False for i in range(18)}
+
+        space = create_symbolic_observation_space()
+        obs = process_symbolic_observation(
+            mock_agent,
+            episode_steps=500,
+            max_episode_steps=1000,
+            visited_locations={(1, 2, 1)},
+        )
+
+        assert space.contains(obs)
+
+    def test_symbolic_graceful_flag_failure(self, mock_agent):
+        """If event flag reading fails, zeros are used (no crash)."""
+        # Don't mock read_boulder_path_flags — let the import fail
+        # or the mock memory cause an exception
+        obs = process_symbolic_observation(
+            mock_agent,
+            episode_steps=0,
+            max_episode_steps=1000,
+            visited_locations=set(),
+        )
+
+        # Should still return a valid vector
+        assert obs.shape == (SYMBOLIC_DIM,)
+        # Event flag positions should be zero
+        flag_start = 9
+        for i in range(18):
+            assert obs[flag_start + i] == 0.0
+
+
+class TestHybridObservation:
+    """Test hybrid observation space and processing (Treatment 3)."""
+
+    @pytest.fixture
+    def mock_agent(self):
+        """Create a mock agent with screen + game state."""
+        agent = Mock()
+        agent.get_screen_array = Mock(
+            return_value=np.random.randint(0, 255, (144, 160, 3), dtype=np.uint8)
+        )
+        agent.get_player_position = Mock(return_value={'x': 10, 'y': 20, 'map': 3})
+        agent.get_player_stats = Mock(return_value={
+            'level': 15,
+            'current_hp': 40,
+            'max_hp': 50,
+            'badges': 1,
+            'party_count': 3,
+        })
+        agent.memory = Mock()
+        return agent
+
+    def test_create_hybrid_space_structure(self):
+        """Hybrid space is Dict with 'screen' and 'game_state' keys."""
+        space = create_hybrid_observation_space()
+
+        assert isinstance(space, gym.spaces.Dict)
+        assert "screen" in space.spaces
+        assert "game_state" in space.spaces
+
+    def test_hybrid_screen_subspace(self):
+        """Hybrid 'screen' subspace is Box(72, 80, 1, uint8)."""
+        space = create_hybrid_observation_space()
+        screen_space = space.spaces["screen"]
+
+        assert isinstance(screen_space, gym.spaces.Box)
+        assert screen_space.shape == (72, 80, 1)
+        assert screen_space.dtype == np.uint8
+
+    def test_hybrid_game_state_subspace(self):
+        """Hybrid 'game_state' subspace is Box(29, float32)."""
+        space = create_hybrid_observation_space()
+        gs_space = space.spaces["game_state"]
+
+        assert isinstance(gs_space, gym.spaces.Box)
+        assert gs_space.shape == (SYMBOLIC_DIM,)
+        assert gs_space.dtype == np.float32
+
+    def test_hybrid_custom_screen_size(self):
+        """Hybrid space respects custom screen_size."""
+        space = create_hybrid_observation_space(screen_size=(40, 36))
+        screen_space = space.spaces["screen"]
+
+        assert screen_space.shape == (36, 40, 1)
+
+    @patch("pokemon_red_ai.game.event_flags.read_boulder_path_flags")
+    def test_process_hybrid_observation_structure(self, mock_flags, mock_agent):
+        """process_hybrid_observation returns dict with both keys."""
+        mock_flags.return_value = {f"flag_{i}": False for i in range(18)}
+
+        obs = process_hybrid_observation(
+            mock_agent,
+            episode_steps=100,
+            max_episode_steps=1000,
+            visited_locations={(1, 2, 1)},
+        )
+
+        assert isinstance(obs, dict)
+        assert "screen" in obs
+        assert "game_state" in obs
+
+    @patch("pokemon_red_ai.game.event_flags.read_boulder_path_flags")
+    def test_hybrid_screen_shape(self, mock_flags, mock_agent):
+        """Hybrid screen component is (72, 80, 1) uint8."""
+        mock_flags.return_value = {f"flag_{i}": False for i in range(18)}
+
+        obs = process_hybrid_observation(
+            mock_agent,
+            episode_steps=100,
+            max_episode_steps=1000,
+            visited_locations=set(),
+        )
+
+        assert obs["screen"].shape == (72, 80, 1)
+        assert obs["screen"].dtype == np.uint8
+
+    @patch("pokemon_red_ai.game.event_flags.read_boulder_path_flags")
+    def test_hybrid_game_state_shape(self, mock_flags, mock_agent):
+        """Hybrid game_state component is (29,) float32."""
+        mock_flags.return_value = {f"flag_{i}": False for i in range(18)}
+
+        obs = process_hybrid_observation(
+            mock_agent,
+            episode_steps=100,
+            max_episode_steps=1000,
+            visited_locations=set(),
+        )
+
+        assert obs["game_state"].shape == (SYMBOLIC_DIM,)
+        assert obs["game_state"].dtype == np.float32
+
+    @patch("pokemon_red_ai.game.event_flags.read_boulder_path_flags")
+    def test_hybrid_game_state_normalized(self, mock_flags, mock_agent):
+        """Hybrid game_state values are in [0, 1]."""
+        mock_flags.return_value = {f"flag_{i}": (i % 2 == 0) for i in range(18)}
+
+        obs = process_hybrid_observation(
+            mock_agent,
+            episode_steps=500,
+            max_episode_steps=1000,
+            visited_locations={(1, 2, 1), (3, 4, 2)},
+        )
+
+        gs = obs["game_state"]
+        assert gs.min() >= 0.0
+        assert gs.max() <= 1.0
 
 
 if __name__ == '__main__':

--- a/tests/unit/training/test_models.py
+++ b/tests/unit/training/test_models.py
@@ -17,6 +17,7 @@ from pokemon_red_ai.training.models import (
     create_dqn_model,
     create_model,
     get_policy_kwargs_for_observation_type,
+    get_policy_type_for_observation,
     PokemonFeaturesExtractor
 )
 
@@ -747,6 +748,101 @@ class TestBackwardCompatibility:
         # Should always have these for multi_modal
         assert 'features_extractor_class' in kwargs
         assert 'net_arch' in kwargs
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Paper observation treatment: policy kwargs & policy type selection
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestPaperPolicyKwargs:
+    """Test policy kwargs for the 3 paper observation treatments."""
+
+    @pytest.mark.parametrize("obs_type", ["pixel", "symbolic", "hybrid"])
+    def test_paper_obs_types_return_dict(self, obs_type):
+        """All paper observation types return a non-empty dict."""
+        kwargs = get_policy_kwargs_for_observation_type(obs_type)
+
+        assert isinstance(kwargs, dict)
+        assert len(kwargs) > 0
+
+    @pytest.mark.parametrize("obs_type", ["pixel", "symbolic", "hybrid"])
+    def test_paper_obs_types_have_net_arch(self, obs_type):
+        """All paper observation types include a net_arch."""
+        kwargs = get_policy_kwargs_for_observation_type(obs_type)
+
+        assert "net_arch" in kwargs
+        assert isinstance(kwargs["net_arch"], dict)
+        assert "pi" in kwargs["net_arch"]
+        assert "vf" in kwargs["net_arch"]
+
+    @pytest.mark.parametrize("obs_type", ["pixel", "symbolic", "hybrid"])
+    def test_paper_obs_types_have_activation_fn(self, obs_type):
+        """All paper observation types include an activation function."""
+        kwargs = get_policy_kwargs_for_observation_type(obs_type)
+
+        assert "activation_fn" in kwargs
+
+
+class TestGetPolicyTypeForObservation:
+    """Test get_policy_type_for_observation() mapping."""
+
+    # ── Paper treatments ────────────────────────────────────────────
+
+    def test_pixel_ppo_returns_cnn_policy(self):
+        assert get_policy_type_for_observation("pixel", "PPO") == "CnnPolicy"
+
+    def test_pixel_rppo_returns_cnn_lstm_policy(self):
+        assert get_policy_type_for_observation("pixel", "RecurrentPPO") == "CnnLstmPolicy"
+
+    def test_symbolic_ppo_returns_mlp_policy(self):
+        assert get_policy_type_for_observation("symbolic", "PPO") == "MlpPolicy"
+
+    def test_symbolic_rppo_returns_mlp_lstm_policy(self):
+        assert get_policy_type_for_observation("symbolic", "RecurrentPPO") == "MlpLstmPolicy"
+
+    def test_hybrid_ppo_returns_multi_input_policy(self):
+        assert get_policy_type_for_observation("hybrid", "PPO") == "MultiInputPolicy"
+
+    def test_hybrid_rppo_returns_multi_input_lstm_policy(self):
+        assert get_policy_type_for_observation("hybrid", "RecurrentPPO") == "MultiInputLstmPolicy"
+
+    # ── Legacy types ────────────────────────────────────────────────
+
+    def test_multi_modal_ppo(self):
+        assert get_policy_type_for_observation("multi_modal", "PPO") == "MultiInputPolicy"
+
+    def test_screen_only_ppo(self):
+        assert get_policy_type_for_observation("screen_only", "PPO") == "CnnPolicy"
+
+    def test_minimal_ppo(self):
+        assert get_policy_type_for_observation("minimal", "PPO") == "MlpPolicy"
+
+    # ── Error cases ─────────────────────────────────────────────────
+
+    def test_unknown_observation_type_raises(self):
+        with pytest.raises(ValueError, match="Unknown observation type"):
+            get_policy_type_for_observation("invalid_type", "PPO")
+
+    # ── Parameterized exhaustive check ──────────────────────────────
+
+    @pytest.mark.parametrize("obs_type,algo,expected", [
+        ("pixel", "PPO", "CnnPolicy"),
+        ("pixel", "RecurrentPPO", "CnnLstmPolicy"),
+        ("symbolic", "PPO", "MlpPolicy"),
+        ("symbolic", "RecurrentPPO", "MlpLstmPolicy"),
+        ("hybrid", "PPO", "MultiInputPolicy"),
+        ("hybrid", "RecurrentPPO", "MultiInputLstmPolicy"),
+        ("multi_modal", "PPO", "MultiInputPolicy"),
+        ("multi_modal", "RecurrentPPO", "MultiInputLstmPolicy"),
+        ("screen_only", "PPO", "CnnPolicy"),
+        ("screen_only", "RecurrentPPO", "CnnLstmPolicy"),
+        ("minimal", "PPO", "MlpPolicy"),
+        ("minimal", "RecurrentPPO", "MlpLstmPolicy"),
+    ])
+    def test_all_observation_algorithm_combos(self, obs_type, algo, expected):
+        """Exhaustive check of all observation type × algorithm combinations."""
+        assert get_policy_type_for_observation(obs_type, algo) == expected
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- **Pixel** (Treatment 1): 80×72×1 grayscale screen processed by SB3's NatureCNN. Maps to `CnnPolicy`/`CnnLstmPolicy`.
- **Symbolic** (Treatment 2): 29-element `float32` vector — position(3) + stats(6) + 18 event flags + exploration(2), all normalised to [0,1]. Maps to `MlpPolicy`/`MlpLstmPolicy`.
- **Hybrid** (Treatment 3): `Dict` space combining grayscale screen + symbolic vector, auto-routed by SB3's `CombinedExtractor`. Maps to `MultiInputPolicy`/`MultiInputLstmPolicy`.
- New `get_policy_type_for_observation(obs_type, algorithm)` function for automatic policy string selection across all 6 observation types × 2 algorithms.
- CLI choices extended in `commands.py`, `scripts/train.py`, and `scripts/eval.py`.
- 37 new tests (598 total, all passing).

## Changed files
| File | What |
|------|------|
| `observations.py` | `create_pixel/symbolic/hybrid_observation_space()`, `process_*()`, `_build_symbolic_vector()`, `_screen_to_grayscale()` |
| `gym_env.py` | Observation space creation, `_get_observation()`, `_get_default_observation()` branches |
| `models.py` | `get_policy_kwargs_for_observation_type()` extended, new `get_policy_type_for_observation()` |
| `__init__.py` (×2) | Exports for new public API |
| `commands.py`, `train.py`, `eval.py` | `--observation-type` choices extended |
| `test_observations.py` | 27 new tests: space shapes, values, normalisation, event flags, graceful failure |
| `test_models.py` | 10 new tests: policy kwargs, exhaustive policy-type mapping |
| `conftest.py` | Parameterized `observation_type` fixture updated |

## Test plan
- [x] All 598 unit tests pass (`pytest tests/ -v`)
- [ ] Smoke test: `python scripts/train.py --rom PokemonRed.gb --observation-type pixel --total-timesteps 1000 --no-wandb`
- [ ] Smoke test: `python scripts/train.py --rom PokemonRed.gb --observation-type symbolic --total-timesteps 1000 --no-wandb`
- [ ] Smoke test: `python scripts/train.py --rom PokemonRed.gb --observation-type hybrid --total-timesteps 1000 --no-wandb`

Closes AMC-59, AMC-60, AMC-61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)