### PR TITLE
Add rliable analysis script (AMC-66)

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1,0 +1,1034 @@
+#!/usr/bin/env python3
+"""
+Publication-quality statistical analysis using rliable.
+
+Implements the pre-registered analysis protocol from ``paper/analysis_plan.md``:
+
+- **Point estimates:** IQM (not raw mean) per Agarwal et al. 2021
+- **Confidence intervals:** 95% stratified bootstrap with 2,000 resamples
+- **Significance test:** Probability of Improvement > 0.75
+- **Plots:** aggregate metrics, performance profiles, probability-of-improvement
+  heatmap, sample-efficiency curves
+
+Input data comes from ``scripts/eval.py`` JSON outputs, organized as::
+
+    eval_results/
+    +-- pixel/
+    |   +-- seed_0.json
+    |   +-- seed_1.json
+    +-- symbolic/
+    |   +-- seed_0.json
+    |   +-- seed_1.json
+    +-- hybrid/
+        +-- seed_0.json
+        +-- seed_1.json
+
+Or from a single CSV file (see ``--csv``).
+
+Usage::
+
+    # Analyze from eval JSON directory
+    python scripts/analyze.py --results-dir eval_results/
+
+    # Analyze from CSV
+    python scripts/analyze.py --csv paper/notebooks/all_results.csv
+
+    # Generate only specific plots
+    python scripts/analyze.py --results-dir eval_results/ --plots iqm poi
+
+Run ``python scripts/analyze.py --help`` for all options.
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+
+# Add project root to path
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+logger = logging.getLogger(__name__)
+
+# ──────────────────────────────────────────────────────────────────────
+# Constants
+# ──────────────────────────────────────────────────────────────────────
+
+# Treatment display names and colors (consistent across all figures)
+TREATMENT_DISPLAY = {
+    "pixel": "Pixel",
+    "symbolic": "Symbolic",
+    "hybrid": "Hybrid",
+}
+
+TREATMENT_COLORS = {
+    "pixel": "#E24A33",      # warm red
+    "symbolic": "#348ABD",   # blue
+    "hybrid": "#988ED5",     # purple
+}
+
+# Metrics we extract from eval.py JSON and feed to rliable
+METRIC_KEYS = {
+    "brock_win_rate": "Brock Win Rate",
+    "mean_return": "Mean Return",
+    "mean_event_flags_triggered": "Event Flags",
+    "unique_maps_visited": "Unique Maps",
+}
+
+# Pre-registered analysis constants (analysis_plan.md S6)
+BOOTSTRAP_REPS = 2_000
+CONFIDENCE_LEVEL = 0.95
+
+# Figure defaults
+FIGURE_DPI = 300
+FIGURE_FORMAT = "pdf"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Data loading
+# ──────────────────────────────────────────────────────────────────────
+
+
+def load_eval_jsons(results_dir: Path) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    Load eval JSON files organized by treatment subdirectories.
+
+    Expected structure::
+
+        results_dir/
+        +-- pixel/
+        |   +-- seed_0.json    (output of scripts/eval.py)
+        |   +-- seed_1.json
+        +-- symbolic/
+        |   +-- seed_0.json
+        +-- hybrid/
+            +-- seed_0.json
+
+    Returns:
+        Dict mapping treatment name to list of eval metric dicts.
+    """
+    results: Dict[str, List[Dict[str, Any]]] = {}
+
+    if not results_dir.is_dir():
+        raise FileNotFoundError(f"Results directory not found: {results_dir}")
+
+    for treatment_dir in sorted(results_dir.iterdir()):
+        if not treatment_dir.is_dir():
+            continue
+
+        treatment = treatment_dir.name
+        evals = []
+
+        for json_file in sorted(treatment_dir.glob("*.json")):
+            with open(json_file) as f:
+                data = json.load(f)
+            data["_source_file"] = str(json_file)
+            evals.append(data)
+            logger.debug(f"Loaded {json_file} ({len(data)} keys)")
+
+        if evals:
+            results[treatment] = evals
+            logger.info(
+                f"  {treatment}: {len(evals)} seeds loaded"
+            )
+
+    if not results:
+        raise ValueError(
+            f"No eval JSONs found in {results_dir}. "
+            f"Expected subdirectories like pixel/, symbolic/, hybrid/ "
+            f"containing *.json files from scripts/eval.py."
+        )
+
+    return results
+
+
+def load_csv(csv_path: Path) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    Load results from a single CSV file.
+
+    Expected columns: ``treatment``, ``seed``, ``brock_win_rate``,
+    ``mean_return``, ``mean_event_flags_triggered``, ``unique_maps_visited``.
+
+    Returns:
+        Dict mapping treatment name to list of metric dicts (one per seed).
+    """
+    import csv
+
+    results: Dict[str, List[Dict[str, Any]]] = {}
+
+    with open(csv_path) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            treatment = row["treatment"]
+            metrics = {}
+            for key in METRIC_KEYS:
+                raw = row.get(key)
+                if raw is not None:
+                    try:
+                        metrics[key] = float(raw)
+                    except ValueError:
+                        metrics[key] = None
+                else:
+                    metrics[key] = None
+
+            # Carry through extra metadata
+            metrics["seed"] = row.get("seed")
+            metrics["_source_file"] = str(csv_path)
+
+            results.setdefault(treatment, []).append(metrics)
+
+    logger.info(f"Loaded CSV: {csv_path}")
+    for t, evals in results.items():
+        logger.info(f"  {t}: {len(evals)} seeds")
+
+    return results
+
+
+def load_sample_efficiency_csv(csv_path: Path) -> Dict[str, np.ndarray]:
+    """
+    Load sample efficiency data from a CSV.
+
+    Expected columns: ``treatment``, ``seed``, ``timestep``,
+    ``brock_win_rate`` (or whichever metric you want curves for).
+
+    Returns:
+        Dict with keys:
+        - 'frames': 1-D array of timestep values
+        - One key per treatment: (n_seeds, n_frames) array of scores
+    """
+    import csv
+
+    raw: Dict[str, Dict[int, Dict[int, float]]] = {}  # treatment -> seed -> step -> score
+    all_steps = set()
+
+    with open(csv_path) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            treatment = row["treatment"]
+            seed = int(row["seed"])
+            step = int(row["timestep"])
+            score = float(row["brock_win_rate"])
+
+            raw.setdefault(treatment, {}).setdefault(seed, {})[step] = score
+            all_steps.add(step)
+
+    frames = np.array(sorted(all_steps))
+    result: Dict[str, np.ndarray] = {"frames": frames}
+
+    for treatment, seed_data in raw.items():
+        seeds = sorted(seed_data.keys())
+        matrix = np.zeros((len(seeds), len(frames)))
+        for i, seed in enumerate(seeds):
+            for j, step in enumerate(frames):
+                matrix[i, j] = seed_data[seed].get(step, 0.0)
+        result[treatment] = matrix
+
+    return result
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Score matrix construction
+# ──────────────────────────────────────────────────────────────────────
+
+
+def build_score_matrix(
+    results: Dict[str, List[Dict[str, Any]]],
+    metric: str = "brock_win_rate",
+    normalize: bool = False,
+    max_score: Optional[float] = None,
+    min_score: float = 0.0,
+) -> Dict[str, np.ndarray]:
+    """
+    Convert loaded results into the ``scores_dict`` format rliable expects.
+
+    Args:
+        results: Output of ``load_eval_jsons`` or ``load_csv``.
+        metric: Which metric key to extract.
+        normalize: If True, min-max normalize scores to [0, 1].
+        max_score: Max score for normalization (auto-detected if None).
+        min_score: Min score for normalization.
+
+    Returns:
+        Dict mapping treatment name to (n_seeds, 1) array.
+        rliable's second axis is task index; we have a single task.
+    """
+    scores_dict: Dict[str, np.ndarray] = {}
+
+    for treatment, evals in results.items():
+        values = []
+        for e in evals:
+            val = e.get(metric)
+            if val is None:
+                logger.warning(
+                    f"Missing metric '{metric}' in {e.get('_source_file', '?')}, "
+                    f"using 0.0"
+                )
+                val = 0.0
+            values.append(float(val))
+
+        arr = np.array(values).reshape(-1, 1)  # (n_seeds, 1)
+
+        if normalize:
+            if max_score is None:
+                max_score = float(arr.max()) if arr.max() > min_score else 1.0
+            arr = (arr - min_score) / (max_score - min_score)
+            arr = np.clip(arr, 0.0, 1.0)
+
+        scores_dict[treatment] = arr
+        logger.debug(
+            f"  {treatment}: {len(values)} seeds, "
+            f"values={[f'{v:.3f}' for v in values]}"
+        )
+
+    return scores_dict
+
+
+# ──────────────────────────────────────────────────────────────────────
+# rliable analysis functions
+# ──────────────────────────────────────────────────────────────────────
+
+
+def compute_aggregate_metrics(
+    scores_dict: Dict[str, np.ndarray],
+    reps: int = BOOTSTRAP_REPS,
+) -> Tuple[Dict[str, Dict[str, float]], Dict[str, Dict[str, np.ndarray]]]:
+    """
+    Compute IQM, mean, median, and optimality gap with bootstrap CIs.
+
+    Returns:
+        (point_estimates, interval_estimates) — each a dict mapping
+        metric name to {treatment: value} or {treatment: [lo, hi]}.
+    """
+    from rliable import library as rly
+    from rliable import metrics
+
+    aggregate_func = lambda x: np.array([
+        metrics.aggregate_iqm(x),
+        metrics.aggregate_mean(x),
+        metrics.aggregate_median(x),
+        metrics.aggregate_optimality_gap(x),
+    ])
+
+    aggregate_scores, aggregate_cis = rly.get_interval_estimates(
+        scores_dict,
+        aggregate_func,
+        reps=reps,
+    )
+
+    metric_names = ["IQM", "Mean", "Median", "Optimality Gap"]
+
+    point_estimates: Dict[str, Dict[str, float]] = {}
+    interval_estimates: Dict[str, Dict[str, np.ndarray]] = {}
+
+    for i, name in enumerate(metric_names):
+        point_estimates[name] = {}
+        interval_estimates[name] = {}
+        for treatment in scores_dict:
+            point_estimates[name][treatment] = float(
+                aggregate_scores[treatment][i]
+            )
+            interval_estimates[name][treatment] = aggregate_cis[treatment][:, i]
+
+    return point_estimates, interval_estimates
+
+
+def compute_probability_of_improvement(
+    scores_dict: Dict[str, np.ndarray],
+    reps: int = BOOTSTRAP_REPS,
+) -> Tuple[Dict[Tuple[str, str], float], Dict[Tuple[str, str], np.ndarray]]:
+    """
+    Compute pairwise Probability of Improvement between all treatments.
+
+    A treatment A is considered superior to B if P(A > B) > 0.75
+    and the 95% CI excludes 0.5 (analysis_plan.md S6).
+
+    Uses stratified bootstrap to compute CIs on the POI estimate,
+    since ``metrics.probability_of_improvement(scores_x, scores_y)``
+    takes two separate arrays and cannot go through
+    ``get_interval_estimates``.
+
+    Returns:
+        (poi_point, poi_ci): dicts mapping (treatment_a, treatment_b)
+        to P(A > B) point estimate and [lo, hi] CI.
+    """
+    from rliable import metrics
+
+    treatments = sorted(scores_dict.keys())
+    poi_point: Dict[Tuple[str, str], float] = {}
+    poi_ci: Dict[Tuple[str, str], np.ndarray] = {}
+
+    alpha = (1 - CONFIDENCE_LEVEL) / 2  # 0.025 for 95% CI
+
+    for i, t_a in enumerate(treatments):
+        for j, t_b in enumerate(treatments):
+            if i >= j:
+                continue
+
+            scores_a = scores_dict[t_a]  # (n_seeds_a, 1)
+            scores_b = scores_dict[t_b]  # (n_seeds_b, 1)
+
+            # Point estimate
+            poi_ab = float(metrics.probability_of_improvement(scores_a, scores_b))
+            poi_ba = 1.0 - poi_ab
+
+            # Bootstrap CI by resampling seed indices
+            n_a, n_b = scores_a.shape[0], scores_b.shape[0]
+            boot_pois = np.zeros(reps)
+            rng = np.random.RandomState(42)
+
+            for r in range(reps):
+                idx_a = rng.choice(n_a, size=n_a, replace=True)
+                idx_b = rng.choice(n_b, size=n_b, replace=True)
+                boot_pois[r] = metrics.probability_of_improvement(
+                    scores_a[idx_a], scores_b[idx_b],
+                )
+
+            ci_lo = float(np.percentile(boot_pois, 100 * alpha))
+            ci_hi = float(np.percentile(boot_pois, 100 * (1 - alpha)))
+
+            poi_point[(t_a, t_b)] = poi_ab
+            poi_ci[(t_a, t_b)] = np.array([ci_lo, ci_hi])
+
+            poi_point[(t_b, t_a)] = poi_ba
+            poi_ci[(t_b, t_a)] = np.array([1.0 - ci_hi, 1.0 - ci_lo])
+
+    return poi_point, poi_ci
+
+
+def compute_performance_profiles(
+    scores_dict: Dict[str, np.ndarray],
+    tau_range: Optional[np.ndarray] = None,
+    reps: int = BOOTSTRAP_REPS,
+) -> Tuple[np.ndarray, Dict[str, np.ndarray], Dict[str, np.ndarray]]:
+    """
+    Compute performance profiles (fraction of runs above threshold tau).
+
+    Returns:
+        (taus, profile_point, profile_ci): threshold array, point estimates,
+        and bootstrap CIs per treatment.
+    """
+    from rliable import library as rly
+
+    if tau_range is None:
+        tau_range = np.linspace(0.0, 1.0, 51)
+
+    profiles, profile_cis = rly.create_performance_profile(
+        scores_dict,
+        tau_list=tau_range,
+        reps=reps,
+    )
+
+    return tau_range, profiles, profile_cis
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Plotting
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _setup_matplotlib() -> None:
+    """Configure matplotlib for publication-quality figures."""
+    matplotlib.rcParams.update({
+        "font.family": "serif",
+        "font.size": 11,
+        "axes.labelsize": 12,
+        "axes.titlesize": 13,
+        "legend.fontsize": 10,
+        "xtick.labelsize": 10,
+        "ytick.labelsize": 10,
+        "figure.dpi": FIGURE_DPI,
+        "savefig.dpi": FIGURE_DPI,
+        "savefig.bbox": "tight",
+        "savefig.pad_inches": 0.05,
+        "axes.grid": True,
+        "grid.alpha": 0.3,
+        "axes.spines.top": False,
+        "axes.spines.right": False,
+    })
+
+
+def _get_color(treatment: str) -> str:
+    """Get the color for a treatment, with a fallback."""
+    return TREATMENT_COLORS.get(treatment, "#333333")
+
+
+def _get_label(treatment: str) -> str:
+    """Get the display label for a treatment."""
+    return TREATMENT_DISPLAY.get(treatment, treatment.title())
+
+
+def plot_aggregate_metrics(
+    point_estimates: Dict[str, Dict[str, float]],
+    interval_estimates: Dict[str, Dict[str, np.ndarray]],
+    metric_name: str = "IQM",
+    output_path: Optional[Path] = None,
+    title: Optional[str] = None,
+) -> plt.Figure:
+    """
+    Bar chart of aggregate metric with bootstrap CIs.
+
+    Produces the main result figure showing IQM across treatments.
+    """
+    treatments = sorted(point_estimates[metric_name].keys())
+    values = [point_estimates[metric_name][t] for t in treatments]
+    cis = [interval_estimates[metric_name][t] for t in treatments]
+
+    colors = [_get_color(t) for t in treatments]
+    labels = [_get_label(t) for t in treatments]
+
+    # Compute error bars (distance from point estimate to CI bounds)
+    errors = np.array([
+        [v - ci[0], ci[1] - v] for v, ci in zip(values, cis)
+    ]).T
+
+    fig, ax = plt.subplots(figsize=(5, 3.5))
+    x = np.arange(len(treatments))
+
+    bars = ax.bar(
+        x, values, yerr=errors,
+        color=colors, edgecolor="white", linewidth=0.5,
+        capsize=4, error_kw={"linewidth": 1.5},
+        width=0.6,
+    )
+
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels)
+    ax.set_ylabel(metric_name)
+
+    if title:
+        ax.set_title(title)
+    else:
+        ax.set_title(
+            f"{metric_name} (Brock Win Rate)\n"
+            f"95% Bootstrap CI, {BOOTSTRAP_REPS:,} resamples"
+        )
+
+    # Annotate values
+    for bar, val, ci in zip(bars, values, cis):
+        ax.text(
+            bar.get_x() + bar.get_width() / 2,
+            ci[1] + 0.02,
+            f"{val:.3f}",
+            ha="center", va="bottom", fontsize=9,
+        )
+
+    fig.tight_layout()
+
+    if output_path:
+        fig.savefig(output_path, format=FIGURE_FORMAT)
+        logger.info(f"Saved: {output_path}")
+
+    return fig
+
+
+def plot_performance_profiles(
+    taus: np.ndarray,
+    profiles: Dict[str, np.ndarray],
+    profile_cis: Dict[str, np.ndarray],
+    output_path: Optional[Path] = None,
+    title: Optional[str] = None,
+) -> plt.Figure:
+    """
+    Performance profile plot: fraction of runs achieving score >= tau.
+    """
+    fig, ax = plt.subplots(figsize=(5, 3.5))
+
+    for treatment in sorted(profiles.keys()):
+        color = _get_color(treatment)
+        label = _get_label(treatment)
+
+        profile = profiles[treatment]
+        ci = profile_cis[treatment]
+
+        ax.plot(taus, profile, color=color, label=label, linewidth=2)
+        ax.fill_between(
+            taus, ci[0], ci[1],
+            color=color, alpha=0.15,
+        )
+
+    ax.set_xlabel(r"Normalized Score ($\tau$)")
+    ax.set_ylabel(r"Fraction of runs with score $\geq \tau$")
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1.05)
+    ax.legend(loc="lower left")
+
+    if title:
+        ax.set_title(title)
+    else:
+        ax.set_title("Performance Profiles")
+
+    fig.tight_layout()
+
+    if output_path:
+        fig.savefig(output_path, format=FIGURE_FORMAT)
+        logger.info(f"Saved: {output_path}")
+
+    return fig
+
+
+def plot_probability_of_improvement(
+    poi_point: Dict[Tuple[str, str], float],
+    poi_ci: Dict[Tuple[str, str], np.ndarray],
+    output_path: Optional[Path] = None,
+    title: Optional[str] = None,
+) -> plt.Figure:
+    """
+    Heatmap of pairwise Probability of Improvement.
+
+    Cells where P(A > B) > 0.75 with CI excluding 0.5 are highlighted
+    per the pre-registered significance threshold.
+    """
+    treatments = sorted({t for pair in poi_point for t in pair})
+    n = len(treatments)
+
+    matrix = np.full((n, n), 0.5)
+    significant = np.zeros((n, n), dtype=bool)
+
+    for i, t_a in enumerate(treatments):
+        for j, t_b in enumerate(treatments):
+            if i == j:
+                continue
+            key = (t_a, t_b)
+            if key in poi_point:
+                matrix[i, j] = poi_point[key]
+                ci = poi_ci[key]
+                # Significant if P(A > B) > 0.75 and CI excludes 0.5
+                significant[i, j] = (
+                    poi_point[key] > 0.75 and ci[0] > 0.5
+                )
+
+    fig, ax = plt.subplots(figsize=(4.5, 4))
+
+    im = ax.imshow(
+        matrix, cmap="RdYlGn", vmin=0.0, vmax=1.0,
+        aspect="equal",
+    )
+
+    labels = [_get_label(t) for t in treatments]
+    ax.set_xticks(range(n))
+    ax.set_yticks(range(n))
+    ax.set_xticklabels(labels, rotation=45, ha="right")
+    ax.set_yticklabels(labels)
+
+    # Annotate cells
+    for i in range(n):
+        for j in range(n):
+            if i == j:
+                ax.text(j, i, "—", ha="center", va="center", fontsize=11)
+                continue
+
+            val = matrix[i, j]
+            sig_marker = "*" if significant[i, j] else ""
+            color = "white" if (val > 0.7 or val < 0.3) else "black"
+
+            ax.text(
+                j, i, f"{val:.2f}{sig_marker}",
+                ha="center", va="center",
+                fontsize=10, color=color, fontweight="bold",
+            )
+
+    ax.set_xlabel("B (column)")
+    ax.set_ylabel("A (row)")
+
+    cbar = fig.colorbar(im, ax=ax, shrink=0.8)
+    cbar.set_label("P(A > B)")
+
+    if title:
+        ax.set_title(title)
+    else:
+        ax.set_title("Probability of Improvement\n(* = significant, P > 0.75, CI excl. 0.5)")
+
+    fig.tight_layout()
+
+    if output_path:
+        fig.savefig(output_path, format=FIGURE_FORMAT)
+        logger.info(f"Saved: {output_path}")
+
+    return fig
+
+
+def plot_sample_efficiency(
+    frames: np.ndarray,
+    scores_dict: Dict[str, np.ndarray],
+    output_path: Optional[Path] = None,
+    title: Optional[str] = None,
+    reps: int = BOOTSTRAP_REPS,
+) -> plt.Figure:
+    """
+    Sample efficiency curves with bootstrap CIs.
+
+    Shows IQM at each checkpoint across training, revealing which
+    treatment learns faster.
+
+    Args:
+        frames: 1-D array of timestep values.
+        scores_dict: Dict mapping treatment to (n_seeds, n_frames) array.
+        output_path: Where to save the figure.
+        title: Optional title override.
+        reps: Bootstrap resamples.
+    """
+    from rliable import library as rly
+    from rliable import metrics
+
+    fig, ax = plt.subplots(figsize=(6, 4))
+
+    for treatment in sorted(scores_dict.keys()):
+        color = _get_color(treatment)
+        label = _get_label(treatment)
+        data = scores_dict[treatment]  # (n_seeds, n_frames)
+
+        # Compute IQM and CI at each frame
+        iqm_values = np.zeros(len(frames))
+        ci_lo = np.zeros(len(frames))
+        ci_hi = np.zeros(len(frames))
+
+        for t_idx in range(len(frames)):
+            col = data[:, t_idx:t_idx + 1]  # (n_seeds, 1)
+            single_scores = {treatment: col}
+
+            try:
+                agg, agg_ci = rly.get_interval_estimates(
+                    single_scores,
+                    metrics.aggregate_iqm,
+                    reps=reps,
+                )
+                iqm_values[t_idx] = float(agg[treatment])
+                ci_lo[t_idx] = float(agg_ci[treatment][0])
+                ci_hi[t_idx] = float(agg_ci[treatment][1])
+            except Exception:
+                iqm_values[t_idx] = np.mean(col)
+                ci_lo[t_idx] = np.percentile(col, 2.5)
+                ci_hi[t_idx] = np.percentile(col, 97.5)
+
+        ax.plot(frames, iqm_values, color=color, label=label, linewidth=2)
+        ax.fill_between(frames, ci_lo, ci_hi, color=color, alpha=0.15)
+
+    ax.set_xlabel("Environment Steps")
+    ax.set_ylabel("IQM (Brock Win Rate)")
+    ax.legend()
+
+    if title:
+        ax.set_title(title)
+    else:
+        ax.set_title(
+            f"Sample Efficiency\n"
+            f"IQM with 95% Bootstrap CI ({reps:,} resamples)"
+        )
+
+    # Format x-axis with M suffix
+    ax.xaxis.set_major_formatter(
+        matplotlib.ticker.FuncFormatter(lambda x, _: f"{x / 1e6:.0f}M")
+    )
+
+    fig.tight_layout()
+
+    if output_path:
+        fig.savefig(output_path, format=FIGURE_FORMAT)
+        logger.info(f"Saved: {output_path}")
+
+    return fig
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Summary report
+# ──────────────────────────────────────────────────────────────────────
+
+
+def print_summary_report(
+    results: Dict[str, List[Dict[str, Any]]],
+    point_estimates: Dict[str, Dict[str, float]],
+    interval_estimates: Dict[str, Dict[str, np.ndarray]],
+    poi_point: Optional[Dict[Tuple[str, str], float]] = None,
+    poi_ci: Optional[Dict[Tuple[str, str], np.ndarray]] = None,
+) -> str:
+    """
+    Print and return a human-readable summary of all analysis results.
+    """
+    lines: List[str] = []
+    sep = "=" * 65
+
+    lines.append(sep)
+    lines.append("RLIABLE ANALYSIS REPORT")
+    lines.append(f"Pre-registered protocol: analysis_plan.md S6")
+    lines.append(f"Bootstrap resamples: {BOOTSTRAP_REPS:,}")
+    lines.append(sep)
+
+    # Data summary
+    lines.append("\nDATA SUMMARY")
+    lines.append("-" * 40)
+    for treatment, evals in sorted(results.items()):
+        label = _get_label(treatment)
+        lines.append(f"  {label:12s}: {len(evals)} seeds")
+
+    # Aggregate metrics
+    lines.append(f"\nAGGREGATE METRICS (Brock Win Rate)")
+    lines.append("-" * 40)
+    for metric_name in ["IQM", "Mean", "Median", "Optimality Gap"]:
+        if metric_name not in point_estimates:
+            continue
+        lines.append(f"\n  {metric_name}:")
+        for treatment in sorted(point_estimates[metric_name].keys()):
+            label = _get_label(treatment)
+            val = point_estimates[metric_name][treatment]
+            ci = interval_estimates[metric_name][treatment]
+            lines.append(
+                f"    {label:12s}: {val:.4f}  "
+                f"[{ci[0]:.4f}, {ci[1]:.4f}]"
+            )
+
+    # Probability of improvement
+    if poi_point:
+        lines.append(f"\nPROBABILITY OF IMPROVEMENT")
+        lines.append("-" * 40)
+        for (t_a, t_b), val in sorted(poi_point.items()):
+            ci = poi_ci[(t_a, t_b)]
+            label_a = _get_label(t_a)
+            label_b = _get_label(t_b)
+            sig = ""
+            if val > 0.75 and ci[0] > 0.5:
+                sig = " *SIGNIFICANT*"
+            lines.append(
+                f"  P({label_a} > {label_b}): "
+                f"{val:.3f}  [{ci[0]:.3f}, {ci[1]:.3f}]{sig}"
+            )
+
+    lines.append(f"\n{sep}")
+    lines.append("* Significant = P > 0.75 with 95% CI excluding 0.5")
+    lines.append(sep)
+
+    report = "\n".join(lines)
+    print(report)
+    return report
+
+
+# ──────────────────────────────────────────────────────────────────────
+# CLI
+# ──────────────────────────────────────────────────────────────────────
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=(
+            "Publication-quality statistical analysis of Pokemon Red AI "
+            "experiments using rliable (Agarwal et al. 2021)."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    # Input data (mutually exclusive)
+    input_group = p.add_mutually_exclusive_group(required=True)
+    input_group.add_argument(
+        "--results-dir", type=Path,
+        help="Directory containing treatment subdirectories with eval JSONs.",
+    )
+    input_group.add_argument(
+        "--csv", type=Path,
+        help="CSV file with columns: treatment, seed, brock_win_rate, ...",
+    )
+
+    # Sample efficiency (optional, separate data source)
+    p.add_argument(
+        "--efficiency-csv", type=Path, default=None,
+        help=(
+            "CSV file for sample efficiency curves. Columns: "
+            "treatment, seed, timestep, brock_win_rate."
+        ),
+    )
+
+    # Metric to analyze
+    p.add_argument(
+        "--metric", type=str, default="brock_win_rate",
+        choices=list(METRIC_KEYS.keys()),
+        help="Primary metric to analyze.",
+    )
+
+    # Which plots to generate
+    p.add_argument(
+        "--plots", nargs="+", default=["all"],
+        choices=["all", "iqm", "profiles", "poi", "efficiency"],
+        help="Which plots to generate.",
+    )
+
+    # Normalization
+    p.add_argument(
+        "--normalize", action="store_true",
+        help="Min-max normalize scores to [0, 1] for rliable.",
+    )
+    p.add_argument(
+        "--max-score", type=float, default=None,
+        help="Maximum score for normalization (auto if omitted).",
+    )
+
+    # Output
+    p.add_argument(
+        "--output-dir", type=Path,
+        default=Path("paper/figures"),
+        help="Directory for output figures.",
+    )
+    p.add_argument(
+        "--report-file", type=Path, default=None,
+        help="Write the text report to a file.",
+    )
+    p.add_argument(
+        "--format", type=str, default="pdf",
+        choices=["pdf", "png", "svg"],
+        help="Figure output format.",
+    )
+
+    # Bootstrap
+    p.add_argument(
+        "--reps", type=int, default=BOOTSTRAP_REPS,
+        help="Number of bootstrap resamples.",
+    )
+
+    # Misc
+    p.add_argument(
+        "--no-show", action="store_true",
+        help="Do not display figures (useful in CI/headless).",
+    )
+    p.add_argument(
+        "-v", "--verbose", action="count", default=0,
+        help="Increase verbosity (-v INFO, -vv DEBUG).",
+    )
+
+    return p
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    # Logging
+    level = {0: logging.WARNING, 1: logging.INFO}.get(args.verbose, logging.DEBUG)
+    logging.basicConfig(
+        level=level,
+        format="[%(asctime)s] %(name)s %(levelname)s - %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    # Override module-level constants from CLI
+    global BOOTSTRAP_REPS, FIGURE_FORMAT
+    BOOTSTRAP_REPS = args.reps
+    FIGURE_FORMAT = args.format
+
+    _setup_matplotlib()
+    if args.no_show:
+        matplotlib.use("Agg")
+
+    # Create output directory
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    # ── Load data ────────────────────────────────────────────────────
+    logger.info("Loading evaluation results...")
+
+    if args.results_dir:
+        results = load_eval_jsons(args.results_dir)
+    else:
+        results = load_csv(args.csv)
+
+    # ── Build score matrix ───────────────────────────────────────────
+    logger.info(f"Building score matrix for metric: {args.metric}")
+
+    scores_dict = build_score_matrix(
+        results,
+        metric=args.metric,
+        normalize=args.normalize,
+        max_score=args.max_score,
+    )
+
+    # Validate minimum seed count
+    for treatment, arr in scores_dict.items():
+        n_seeds = arr.shape[0]
+        if n_seeds < 3:
+            logger.warning(
+                f"{treatment}: only {n_seeds} seed(s). "
+                f"rliable recommends >= 5 seeds for reliable CIs. "
+                f"Results may be unstable."
+            )
+
+    # ── Compute aggregate metrics ────────────────────────────────────
+    plots_to_make = set(args.plots)
+    if "all" in plots_to_make:
+        plots_to_make = {"iqm", "profiles", "poi", "efficiency"}
+
+    logger.info("Computing aggregate metrics (IQM, Mean, Median)...")
+    point_estimates, interval_estimates = compute_aggregate_metrics(
+        scores_dict, reps=args.reps,
+    )
+
+    # ── Probability of improvement ───────────────────────────────────
+    poi_point, poi_ci = None, None
+    if len(scores_dict) >= 2:
+        logger.info("Computing probability of improvement...")
+        poi_point, poi_ci = compute_probability_of_improvement(
+            scores_dict, reps=args.reps,
+        )
+
+    # ── Summary report ───────────────────────────────────────────────
+    report = print_summary_report(
+        results, point_estimates, interval_estimates,
+        poi_point, poi_ci,
+    )
+
+    if args.report_file:
+        args.report_file.parent.mkdir(parents=True, exist_ok=True)
+        args.report_file.write_text(report)
+        logger.info(f"Report written to {args.report_file}")
+
+    # ── Generate plots ───────────────────────────────────────────────
+    metric_label = METRIC_KEYS.get(args.metric, args.metric)
+    suffix = f".{args.format}"
+
+    if "iqm" in plots_to_make:
+        logger.info("Plotting aggregate metrics...")
+        plot_aggregate_metrics(
+            point_estimates, interval_estimates,
+            metric_name="IQM",
+            output_path=args.output_dir / f"aggregate_iqm{suffix}",
+        )
+
+    if "profiles" in plots_to_make:
+        logger.info("Computing and plotting performance profiles...")
+        taus, profiles, profile_cis = compute_performance_profiles(
+            scores_dict, reps=args.reps,
+        )
+        plot_performance_profiles(
+            taus, profiles, profile_cis,
+            output_path=args.output_dir / f"performance_profiles{suffix}",
+        )
+
+    if "poi" in plots_to_make and poi_point:
+        logger.info("Plotting probability of improvement heatmap...")
+        plot_probability_of_improvement(
+            poi_point, poi_ci,
+            output_path=args.output_dir / f"probability_of_improvement{suffix}",
+        )
+
+    if "efficiency" in plots_to_make and args.efficiency_csv:
+        logger.info("Loading and plotting sample efficiency curves...")
+        efficiency_data = load_sample_efficiency_csv(args.efficiency_csv)
+        frames = efficiency_data.pop("frames")
+        plot_sample_efficiency(
+            frames, efficiency_data,
+            output_path=args.output_dir / f"sample_efficiency{suffix}",
+            reps=args.reps,
+        )
+
+    # Show figures if not headless
+    if not args.no_show:
+        plt.show()
+
+    logger.info("Analysis complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_analyze.py
+++ b/tests/unit/test_analyze.py
@@ -1,0 +1,673 @@
+"""
+Tests for scripts/analyze.py — rliable analysis pipeline.
+
+Covers data loading, score matrix construction, aggregate metric
+computation, probability of improvement, performance profiles,
+and figure generation.
+"""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import matplotlib
+import numpy as np
+import pytest
+
+# Use non-interactive backend for CI
+matplotlib.use("Agg")
+
+import sys
+
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent.parent)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from scripts.analyze import (
+    build_score_matrix,
+    compute_aggregate_metrics,
+    compute_performance_profiles,
+    compute_probability_of_improvement,
+    load_csv,
+    load_eval_jsons,
+    load_sample_efficiency_csv,
+    plot_aggregate_metrics,
+    plot_performance_profiles,
+    plot_probability_of_improvement,
+    plot_sample_efficiency,
+    print_summary_report,
+    METRIC_KEYS,
+    TREATMENT_COLORS,
+    TREATMENT_DISPLAY,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fixtures
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _make_eval_json(
+    brock_win_rate: float = 0.5,
+    mean_return: float = 800.0,
+    seed: int = 0,
+    treatment: str = "hybrid",
+) -> dict:
+    """Create a synthetic eval JSON matching eval.py output schema."""
+    return {
+        "brock_win_rate": brock_win_rate,
+        "mean_return": mean_return,
+        "return_std": 50.0,
+        "mean_event_flags_triggered": 8.0,
+        "max_event_flags_triggered": 12,
+        "unique_maps_visited": 7,
+        "steps_to_pewter": 5000,
+        "steps_to_brock_win": 12000,
+        "n_episodes": 20,
+        "eval_save_state": "save_states/s0_post_intro.state",
+        "checkpoint_path": f"models/{treatment}_seed{seed}.zip",
+        "git_sha": "abc123",
+        "algorithm": "RecurrentPPO",
+        "observation_type": treatment,
+        "seed": seed,
+    }
+
+
+@pytest.fixture
+def eval_results_dir(tmp_path):
+    """Create a temp directory with 3 treatments × 5 seeds of eval JSONs."""
+    rng = np.random.RandomState(42)
+
+    treatments = {
+        "pixel": {"base_wr": 0.15, "base_return": 500},
+        "symbolic": {"base_wr": 0.45, "base_return": 850},
+        "hybrid": {"base_wr": 0.55, "base_return": 920},
+    }
+
+    for treatment, params in treatments.items():
+        tdir = tmp_path / treatment
+        tdir.mkdir()
+        for seed in range(5):
+            data = _make_eval_json(
+                brock_win_rate=max(0, params["base_wr"] + rng.normal(0, 0.1)),
+                mean_return=params["base_return"] + rng.normal(0, 50),
+                seed=seed,
+                treatment=treatment,
+            )
+            (tdir / f"seed_{seed}.json").write_text(json.dumps(data, indent=2))
+
+    return tmp_path
+
+
+@pytest.fixture
+def csv_results(tmp_path):
+    """Create a temp CSV with results."""
+    csv_path = tmp_path / "results.csv"
+    rng = np.random.RandomState(42)
+
+    lines = ["treatment,seed,brock_win_rate,mean_return,mean_event_flags_triggered,unique_maps_visited"]
+    for treatment, base_wr in [("pixel", 0.15), ("symbolic", 0.45), ("hybrid", 0.55)]:
+        for seed in range(5):
+            wr = max(0, base_wr + rng.normal(0, 0.1))
+            ret = 500 + rng.normal(0, 50)
+            lines.append(f"{treatment},{seed},{wr:.4f},{ret:.1f},8.0,7")
+
+    csv_path.write_text("\n".join(lines))
+    return csv_path
+
+
+@pytest.fixture
+def efficiency_csv(tmp_path):
+    """Create a temp CSV with sample efficiency data."""
+    csv_path = tmp_path / "efficiency.csv"
+    rng = np.random.RandomState(42)
+
+    lines = ["treatment,seed,timestep,brock_win_rate"]
+    steps = [1_000_000, 5_000_000, 10_000_000, 50_000_000, 100_000_000]
+
+    for treatment, base_wr in [("pixel", 0.1), ("symbolic", 0.4), ("hybrid", 0.5)]:
+        for seed in range(3):
+            for i, step in enumerate(steps):
+                # Scores increase with timestep
+                wr = min(1.0, max(0, base_wr * (i + 1) / len(steps) + rng.normal(0, 0.05)))
+                lines.append(f"{treatment},{seed},{step},{wr:.4f}")
+
+    csv_path.write_text("\n".join(lines))
+    return csv_path
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Data loading tests
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestLoadEvalJsons:
+    """Tests for loading evaluation JSON files."""
+
+    def test_loads_all_treatments(self, eval_results_dir):
+        results = load_eval_jsons(eval_results_dir)
+        assert set(results.keys()) == {"pixel", "symbolic", "hybrid"}
+
+    def test_correct_seed_count(self, eval_results_dir):
+        results = load_eval_jsons(eval_results_dir)
+        for treatment, evals in results.items():
+            assert len(evals) == 5, f"{treatment} should have 5 seeds"
+
+    def test_metrics_present(self, eval_results_dir):
+        results = load_eval_jsons(eval_results_dir)
+        for treatment, evals in results.items():
+            for e in evals:
+                assert "brock_win_rate" in e
+                assert "mean_return" in e
+                assert "mean_event_flags_triggered" in e
+
+    def test_source_file_tracked(self, eval_results_dir):
+        results = load_eval_jsons(eval_results_dir)
+        for evals in results.values():
+            for e in evals:
+                assert "_source_file" in e
+
+    def test_missing_dir_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_eval_jsons(tmp_path / "nonexistent")
+
+    def test_empty_dir_raises(self, tmp_path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        with pytest.raises(ValueError, match="No eval JSONs found"):
+            load_eval_jsons(empty)
+
+    def test_ignores_non_json_files(self, tmp_path):
+        tdir = tmp_path / "pixel"
+        tdir.mkdir()
+        # Write one valid JSON and one non-JSON file
+        (tdir / "seed_0.json").write_text(json.dumps(_make_eval_json()))
+        (tdir / "notes.txt").write_text("not a json file")
+
+        results = load_eval_jsons(tmp_path)
+        assert len(results["pixel"]) == 1
+
+
+class TestLoadCsv:
+    """Tests for CSV data loading."""
+
+    def test_loads_all_treatments(self, csv_results):
+        results = load_csv(csv_results)
+        assert set(results.keys()) == {"pixel", "symbolic", "hybrid"}
+
+    def test_correct_seed_count(self, csv_results):
+        results = load_csv(csv_results)
+        for treatment, evals in results.items():
+            assert len(evals) == 5
+
+    def test_numeric_conversion(self, csv_results):
+        results = load_csv(csv_results)
+        for evals in results.values():
+            for e in evals:
+                assert isinstance(e["brock_win_rate"], float)
+
+
+class TestLoadSampleEfficiencyCsv:
+    """Tests for sample efficiency CSV loading."""
+
+    def test_has_frames(self, efficiency_csv):
+        data = load_sample_efficiency_csv(efficiency_csv)
+        assert "frames" in data
+        assert len(data["frames"]) == 5  # 5 timestep values
+
+    def test_has_treatments(self, efficiency_csv):
+        data = load_sample_efficiency_csv(efficiency_csv)
+        treatments = {k for k in data if k != "frames"}
+        assert treatments == {"pixel", "symbolic", "hybrid"}
+
+    def test_correct_shape(self, efficiency_csv):
+        data = load_sample_efficiency_csv(efficiency_csv)
+        for treatment in ["pixel", "symbolic", "hybrid"]:
+            assert data[treatment].shape == (3, 5)  # 3 seeds × 5 timesteps
+
+    def test_frames_sorted(self, efficiency_csv):
+        data = load_sample_efficiency_csv(efficiency_csv)
+        frames = data["frames"]
+        assert np.all(frames[:-1] <= frames[1:])
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Score matrix tests
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestBuildScoreMatrix:
+    """Tests for score matrix construction."""
+
+    def test_shape(self, eval_results_dir):
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(results, metric="brock_win_rate")
+
+        for treatment, arr in scores.items():
+            assert arr.shape == (5, 1), f"{treatment} should be (5, 1)"
+
+    def test_values_match_input(self, eval_results_dir):
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(results, metric="brock_win_rate")
+
+        for treatment, evals in results.items():
+            expected = [e["brock_win_rate"] for e in evals]
+            np.testing.assert_array_almost_equal(
+                scores[treatment].flatten(), expected,
+            )
+
+    def test_normalization(self, eval_results_dir):
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(
+            results, metric="mean_return", normalize=True,
+        )
+
+        for arr in scores.values():
+            assert arr.min() >= 0.0
+            assert arr.max() <= 1.0
+
+    def test_normalization_with_custom_max(self, eval_results_dir):
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(
+            results, metric="mean_return",
+            normalize=True, max_score=1500.0,
+        )
+
+        for arr in scores.values():
+            # All values should be < 1.0 since max_score=1500 > all returns
+            assert arr.max() < 1.0
+
+    def test_missing_metric_defaults_to_zero(self, tmp_path):
+        tdir = tmp_path / "pixel"
+        tdir.mkdir()
+        data = {"brock_win_rate": 0.5}  # Missing mean_return
+        (tdir / "seed_0.json").write_text(json.dumps(data))
+
+        results = load_eval_jsons(tmp_path)
+        scores = build_score_matrix(results, metric="mean_return")
+        assert scores["pixel"][0, 0] == 0.0
+
+
+# ──────────────────────────────────────────────────────────────────────
+# rliable computation tests
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestComputeAggregateMetrics:
+    """Tests for IQM, mean, median, optimality gap computation."""
+
+    def test_returns_four_metrics(self, eval_results_dir):
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(results, metric="brock_win_rate")
+
+        point_est, interval_est = compute_aggregate_metrics(scores, reps=100)
+
+        assert set(point_est.keys()) == {"IQM", "Mean", "Median", "Optimality Gap"}
+        assert set(interval_est.keys()) == {"IQM", "Mean", "Median", "Optimality Gap"}
+
+    def test_all_treatments_present(self, eval_results_dir):
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(results, metric="brock_win_rate")
+
+        point_est, interval_est = compute_aggregate_metrics(scores, reps=100)
+
+        for metric_name in ["IQM", "Mean"]:
+            assert set(point_est[metric_name].keys()) == {"pixel", "symbolic", "hybrid"}
+
+    def test_ci_contains_point_estimate(self, eval_results_dir):
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(results, metric="brock_win_rate")
+
+        point_est, interval_est = compute_aggregate_metrics(scores, reps=100)
+
+        for metric_name in ["IQM", "Mean", "Median"]:
+            for treatment in scores:
+                val = point_est[metric_name][treatment]
+                ci = interval_est[metric_name][treatment]
+                # CI should contain the point estimate (within bootstrap noise)
+                assert ci[0] <= val + 0.05, (
+                    f"{metric_name}/{treatment}: CI lo {ci[0]} > val {val}"
+                )
+                assert ci[1] >= val - 0.05, (
+                    f"{metric_name}/{treatment}: CI hi {ci[1]} < val {val}"
+                )
+
+    def test_iqm_within_range(self, eval_results_dir):
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(results, metric="brock_win_rate")
+
+        point_est, _ = compute_aggregate_metrics(scores, reps=100)
+
+        for treatment in scores:
+            iqm = point_est["IQM"][treatment]
+            raw_mean = float(scores[treatment].mean())
+            # IQM should be in a reasonable range around the mean
+            assert 0.0 <= iqm <= 1.0, f"IQM out of range: {iqm}"
+
+    def test_pixel_lower_than_symbolic(self, eval_results_dir):
+        """Validates the synthetic data has expected ordering."""
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(results, metric="brock_win_rate")
+
+        point_est, _ = compute_aggregate_metrics(scores, reps=100)
+
+        assert point_est["IQM"]["pixel"] < point_est["IQM"]["symbolic"]
+
+
+class TestComputeProbabilityOfImprovement:
+    """Tests for pairwise probability of improvement."""
+
+    def test_returns_all_pairs(self, eval_results_dir):
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(results, metric="brock_win_rate")
+
+        poi_point, poi_ci = compute_probability_of_improvement(scores, reps=100)
+
+        # 3 treatments → 6 ordered pairs (A,B) and (B,A)
+        assert len(poi_point) == 6
+        assert len(poi_ci) == 6
+
+    def test_poi_between_0_and_1(self, eval_results_dir):
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(results, metric="brock_win_rate")
+
+        poi_point, _ = compute_probability_of_improvement(scores, reps=100)
+
+        for key, val in poi_point.items():
+            assert 0.0 <= val <= 1.0, f"POI {key} out of range: {val}"
+
+    def test_complementary_pairs(self, eval_results_dir):
+        """P(A > B) + P(B > A) should sum to 1.0."""
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(results, metric="brock_win_rate")
+
+        poi_point, _ = compute_probability_of_improvement(scores, reps=100)
+
+        treatments = sorted(scores.keys())
+        for i, t_a in enumerate(treatments):
+            for j, t_b in enumerate(treatments):
+                if i >= j:
+                    continue
+                ab = poi_point[(t_a, t_b)]
+                ba = poi_point[(t_b, t_a)]
+                assert abs(ab + ba - 1.0) < 1e-6, (
+                    f"P({t_a}>{t_b}) + P({t_b}>{t_a}) = {ab + ba}, expected 1.0"
+                )
+
+    def test_ci_bounds_ordered(self, eval_results_dir):
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(results, metric="brock_win_rate")
+
+        _, poi_ci = compute_probability_of_improvement(scores, reps=100)
+
+        for key, ci in poi_ci.items():
+            assert ci[0] <= ci[1], f"CI for {key}: lo={ci[0]} > hi={ci[1]}"
+
+    def test_symbolic_beats_pixel(self, eval_results_dir):
+        """Synthetic data is designed so symbolic >> pixel."""
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(results, metric="brock_win_rate")
+
+        poi_point, _ = compute_probability_of_improvement(scores, reps=100)
+
+        assert poi_point[("symbolic", "pixel")] > 0.7
+
+
+class TestComputePerformanceProfiles:
+    """Tests for performance profile computation."""
+
+    def test_returns_correct_shape(self, eval_results_dir):
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(results, metric="brock_win_rate")
+
+        taus, profiles, profile_cis = compute_performance_profiles(
+            scores, reps=100,
+        )
+
+        assert len(taus) == 51  # default linspace(0, 1, 51)
+        for treatment in scores:
+            assert profiles[treatment].shape == (51,)
+            assert profile_cis[treatment].shape == (2, 51)
+
+    def test_profiles_monotone_decreasing(self, eval_results_dir):
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(results, metric="brock_win_rate")
+
+        taus, profiles, _ = compute_performance_profiles(scores, reps=100)
+
+        for treatment, profile in profiles.items():
+            # Performance profiles should be monotonically non-increasing
+            for i in range(len(profile) - 1):
+                assert profile[i] >= profile[i + 1] - 0.01, (
+                    f"{treatment}: profile[{i}]={profile[i]:.3f} < "
+                    f"profile[{i+1}]={profile[i+1]:.3f}"
+                )
+
+    def test_starts_at_1_ends_at_0(self, eval_results_dir):
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(results, metric="brock_win_rate")
+
+        taus, profiles, _ = compute_performance_profiles(scores, reps=100)
+
+        for treatment, profile in profiles.items():
+            # At tau=0, all runs should score >= 0
+            assert profile[0] >= 0.9, (
+                f"{treatment}: profile at tau=0 should be ~1.0, got {profile[0]}"
+            )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Plotting tests (smoke tests — verify no crashes, output exists)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestPlotAggregateMetrics:
+    """Smoke tests for aggregate metric bar chart."""
+
+    def test_generates_figure(self, eval_results_dir, tmp_path):
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(results, metric="brock_win_rate")
+        point_est, interval_est = compute_aggregate_metrics(scores, reps=100)
+
+        output = tmp_path / "test_iqm.png"
+        fig = plot_aggregate_metrics(
+            point_est, interval_est,
+            metric_name="IQM",
+            output_path=output,
+        )
+
+        assert output.exists()
+        assert output.stat().st_size > 0
+        import matplotlib.pyplot as plt
+        plt.close(fig)
+
+    def test_returns_figure_object(self, eval_results_dir):
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(results, metric="brock_win_rate")
+        point_est, interval_est = compute_aggregate_metrics(scores, reps=100)
+
+        fig = plot_aggregate_metrics(point_est, interval_est, metric_name="IQM")
+
+        assert isinstance(fig, matplotlib.figure.Figure)
+        import matplotlib.pyplot as plt
+        plt.close(fig)
+
+
+class TestPlotPerformanceProfiles:
+    """Smoke tests for performance profile plot."""
+
+    def test_generates_figure(self, eval_results_dir, tmp_path):
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(results, metric="brock_win_rate")
+        taus, profiles, cis = compute_performance_profiles(scores, reps=100)
+
+        output = tmp_path / "test_profiles.png"
+        fig = plot_performance_profiles(
+            taus, profiles, cis, output_path=output,
+        )
+
+        assert output.exists()
+        assert output.stat().st_size > 0
+        import matplotlib.pyplot as plt
+        plt.close(fig)
+
+
+class TestPlotProbabilityOfImprovement:
+    """Smoke tests for POI heatmap."""
+
+    def test_generates_figure(self, eval_results_dir, tmp_path):
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(results, metric="brock_win_rate")
+        poi_point, poi_ci = compute_probability_of_improvement(scores, reps=100)
+
+        output = tmp_path / "test_poi.png"
+        fig = plot_probability_of_improvement(
+            poi_point, poi_ci, output_path=output,
+        )
+
+        assert output.exists()
+        assert output.stat().st_size > 0
+        import matplotlib.pyplot as plt
+        plt.close(fig)
+
+
+class TestPlotSampleEfficiency:
+    """Smoke tests for sample efficiency curves."""
+
+    def test_generates_figure(self, efficiency_csv, tmp_path):
+        data = load_sample_efficiency_csv(efficiency_csv)
+        frames = data.pop("frames")
+
+        output = tmp_path / "test_efficiency.png"
+        fig = plot_sample_efficiency(
+            frames, data,
+            output_path=output,
+            reps=50,  # fast for tests
+        )
+
+        assert output.exists()
+        assert output.stat().st_size > 0
+        import matplotlib.pyplot as plt
+        plt.close(fig)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Summary report tests
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestPrintSummaryReport:
+    """Tests for the text report generation."""
+
+    def test_contains_treatment_names(self, eval_results_dir):
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(results, metric="brock_win_rate")
+        point_est, interval_est = compute_aggregate_metrics(scores, reps=100)
+
+        report = print_summary_report(
+            results, point_est, interval_est,
+        )
+
+        assert "Pixel" in report
+        assert "Symbolic" in report
+        assert "Hybrid" in report
+
+    def test_contains_iqm(self, eval_results_dir):
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(results, metric="brock_win_rate")
+        point_est, interval_est = compute_aggregate_metrics(scores, reps=100)
+
+        report = print_summary_report(
+            results, point_est, interval_est,
+        )
+
+        assert "IQM" in report
+
+    def test_contains_poi_when_provided(self, eval_results_dir):
+        results = load_eval_jsons(eval_results_dir)
+        scores = build_score_matrix(results, metric="brock_win_rate")
+        point_est, interval_est = compute_aggregate_metrics(scores, reps=100)
+        poi_point, poi_ci = compute_probability_of_improvement(scores, reps=100)
+
+        report = print_summary_report(
+            results, point_est, interval_est,
+            poi_point, poi_ci,
+        )
+
+        assert "PROBABILITY OF IMPROVEMENT" in report
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Constants / config tests
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestConstants:
+    """Tests for module-level constants."""
+
+    def test_all_treatments_have_colors(self):
+        for treatment in ["pixel", "symbolic", "hybrid"]:
+            assert treatment in TREATMENT_COLORS
+
+    def test_all_treatments_have_display_names(self):
+        for treatment in ["pixel", "symbolic", "hybrid"]:
+            assert treatment in TREATMENT_DISPLAY
+
+    def test_metric_keys_valid(self):
+        expected = {
+            "brock_win_rate",
+            "mean_return",
+            "mean_event_flags_triggered",
+            "unique_maps_visited",
+        }
+        assert set(METRIC_KEYS.keys()) == expected
+
+
+# ──────────────────────────────────────────────────────────────────────
+# CLI parser tests
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestCLI:
+    """Tests for the argument parser."""
+
+    def test_results_dir_arg(self):
+        from scripts.analyze import build_parser
+        parser = build_parser()
+        args = parser.parse_args(["--results-dir", "eval_results/"])
+        assert args.results_dir == Path("eval_results/")
+
+    def test_csv_arg(self):
+        from scripts.analyze import build_parser
+        parser = build_parser()
+        args = parser.parse_args(["--csv", "results.csv"])
+        assert args.csv == Path("results.csv")
+
+    def test_mutual_exclusion(self):
+        from scripts.analyze import build_parser
+        parser = build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--results-dir", "dir/", "--csv", "file.csv"])
+
+    def test_default_reps(self):
+        from scripts.analyze import build_parser
+        parser = build_parser()
+        args = parser.parse_args(["--results-dir", "eval_results/"])
+        assert args.reps == 2000
+
+    def test_custom_reps(self):
+        from scripts.analyze import build_parser
+        parser = build_parser()
+        args = parser.parse_args(["--results-dir", "eval_results/", "--reps", "500"])
+        assert args.reps == 500
+
+    def test_plot_choices(self):
+        from scripts.analyze import build_parser
+        parser = build_parser()
+        args = parser.parse_args([
+            "--results-dir", "eval_results/",
+            "--plots", "iqm", "poi",
+        ])
+        assert args.plots == ["iqm", "poi"]


### PR DESCRIPTION
## Summary
- Adds `scripts/analyze.py` — publication-quality statistical analysis using the [rliable](https://github.com/google-research/rliable) library (Agarwal et al. 2021)
- Implements the full pre-registered analysis protocol from `paper/analysis_plan.md` §6:
  - **IQM** (Interquartile Mean) — not raw mean — as the primary aggregate metric
  - **95% stratified bootstrap CIs** with 2,000 resamples (configurable via `--reps`)
  - **Probability of Improvement** > 0.75 with CI excluding 0.5 as the significance threshold
  - **Performance profiles** showing fraction of runs above each score threshold
  - **Sample efficiency curves** with per-checkpoint IQM and bootstrap CIs
- Generates 4 publication-quality figures saved to `paper/figures/`:
  - `aggregate_iqm.pdf` — bar chart with error bars
  - `performance_profiles.pdf` — CDFs per treatment
  - `probability_of_improvement.pdf` — pairwise heatmap with significance markers
  - `sample_efficiency.pdf` — learning curves across training
- Supports two input formats:
  - **JSON directory**: treatment subdirectories with `eval.py` output JSONs
  - **CSV**: flat file with treatment/seed/metric columns
- 49 tests covering data loading, score matrix construction, all rliable computations, plot generation, CLI parsing

### Usage
```bash
# From eval JSON directory (output of scripts/eval.py)
python scripts/analyze.py --results-dir eval_results/ -v

# From CSV
python scripts/analyze.py --csv results.csv --output-dir paper/figures/

# Specific plots only, custom bootstrap count
python scripts/analyze.py --results-dir eval_results/ --plots iqm poi --reps 500
```

## Test plan
- [x] All 49 tests pass (`pytest tests/unit/test_analyze.py -v`)
- [x] End-to-end smoke test with synthetic 3-treatment × 5-seed data produces all 3 figures
- [x] No deprecation warnings
- [x] `rliable==1.2.0` already in `requirements.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)