### PR TITLE
Add training monitoring dashboard (AMC-71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ pokemon-ai train --rom PokemonRed.gb --timesteps 100000
 pokemon-ai test --rom PokemonRed.gb --model models/best_model.zip --episodes 10
 ```
 
+### Monitoring a Training Run
+
+The `scripts/train.py` entrypoint wires in a [`MonitoringCallback`](pokemon_red_ai/training/callbacks.py) that logs map-exploration heatmaps, the 18 Boulder-Path event flags, periodic game-screen captures, and a per-episode breakdown to Weights & Biases. The same data is mirrored to `<save_dir>/dashboard_state.json` so you can inspect a run locally without a W&B account:
+
+```bash
+# Start training (W&B is enabled by default; pass --no-wandb to skip)
+python scripts/train.py --rom PokemonRed.gb --save-dir ./training_output/run1
+
+# In another terminal, launch the local dashboard
+pip install -e ".[dashboard]"          # one-time: install Streamlit
+streamlit run scripts/monitor.py -- --runs-dir ./training_output
+```
+
+The dashboard supports side-by-side run comparison (e.g. multiple seeds) and auto-reads from `dashboard_state.json`, the SB3 `monitor.csv`, and TensorBoard scalars (if present).
+
 ### Using the Python API
 
 ```python

--- a/pokemon_red_ai/training/__init__.py
+++ b/pokemon_red_ai/training/__init__.py
@@ -15,6 +15,8 @@ from .callbacks import (
     EarlyStopping,
     PerformanceMonitor,
     WandbCallback,
+    MonitoringCallback,
+    MONITORED_INFO_KEYS,
 )
 
 # Model creation utilities
@@ -41,6 +43,8 @@ __all__ = [
     "EarlyStopping",
     "PerformanceMonitor",
     "WandbCallback",
+    "MonitoringCallback",
+    "MONITORED_INFO_KEYS",
 
     # Model creation
     "create_ppo_model",

--- a/pokemon_red_ai/training/callbacks.py
+++ b/pokemon_red_ai/training/callbacks.py
@@ -8,11 +8,12 @@ live visualization, and Weights & Biases experiment tracking.
 macOS-compatible version that saves plots to files instead of displaying them live.
 """
 
+import json
 import os
 import numpy as np
 import logging
-from collections import deque
-from typing import Dict, Any, Optional
+from collections import defaultdict, deque
+from typing import Any, Dict, List, Optional
 import matplotlib
 # Use Agg backend (no GUI) to avoid conflicts with SDL on macOS
 matplotlib.use('Agg')
@@ -906,3 +907,399 @@ class WandbCallback(BaseCallback):
                     )
             except Exception as exc:
                 logger.warning(f"W&B artifact upload failed: {exc}")
+
+
+# Info-dict keys the monitoring callback consumes from each env step.  These
+# are the same keys ``PokemonRedGymEnv._get_info()`` populates, so the list
+# doubles as the ``info_keywords`` tuple we pass to ``Monitor`` in
+# ``scripts/train.py`` so they also propagate into ``ep_info_buffer``.
+MONITORED_INFO_KEYS: tuple = (
+    "maps_visited",
+    "badges_earned",
+    "locations_visited",
+    "hp_ratio",
+    "event_progress",
+    "current_map",
+    "unique_maps_list",
+    "player_level",
+)
+
+
+class MonitoringCallback(WandbCallback):
+    """W&B callback with game-specific monitoring extensions.
+
+    Extends :class:`WandbCallback` with research-oriented views that
+    tell the reviewer at a glance whether a run is worth continuing:
+
+    * **Map exploration heatmap** — how many episodes visited each map.
+      Logged as a W&B Table and as a Matplotlib bar chart image so it
+      survives when the Table UI is collapsed.
+    * **Event flag progress** — how many episodes triggered each of the
+      18 pre-registered Boulder Path flags (``game.event_flags``), and
+      the earliest episode in which each flag fired.
+    * **Screen captures** — the game screen captured from the training
+      env every ``screen_capture_freq`` episodes, logged as a W&B image.
+    * **Per-episode breakdown** — reward, length, maps visited, final
+      map, badge count, and event flags triggered for every completed
+      episode.  Logged as a W&B Table and mirrored to a JSON snapshot
+      at ``<save_path>/dashboard_state.json`` so ``scripts/monitor.py``
+      can read the same data without a W&B account.
+
+    All logging failures are caught and logged at DEBUG level — they
+    never interrupt training.
+    """
+
+    def __init__(
+        self,
+        save_freq: int = 50_000,
+        save_path: str = "./models/",
+        log_freq: int = 1,
+        screen_capture_freq: int = 10,
+        dashboard_state_path: Optional[str] = None,
+        verbose: int = 1,
+    ):
+        """
+        Args:
+            save_freq: Checkpoint save frequency (timesteps) — see
+                :class:`WandbCallback`.
+            save_path: Root directory for checkpoints, dashboard state,
+                and any derived artifacts.
+            log_freq: W&B log throttle — only log every Nth rollout.
+            screen_capture_freq: Episodes between screen-capture logs.
+                Set to 0 to disable screen captures entirely.
+            dashboard_state_path: Where to write ``dashboard_state.json``
+                for the local Streamlit dashboard.  Defaults to
+                ``<save_path>/dashboard_state.json``.
+            verbose: 0 silent, 1 info, 2 debug.
+        """
+        super().__init__(
+            save_freq=save_freq,
+            save_path=save_path,
+            log_freq=log_freq,
+            verbose=verbose,
+        )
+        self.screen_capture_freq = max(0, int(screen_capture_freq))
+        self.dashboard_state_path = dashboard_state_path or os.path.join(
+            save_path, "dashboard_state.json"
+        )
+
+        # Per-episode state
+        self._episode_count: int = 0
+        self._episodes_since_screen: int = 0
+        self._map_visit_counts: Dict[int, int] = defaultdict(int)
+        self._flag_trigger_counts: Dict[str, int] = defaultdict(int)
+        self._flag_first_triggered: Dict[str, int] = {}
+        self._episode_rows: List[Dict[str, Any]] = []
+
+        os.makedirs(os.path.dirname(os.path.abspath(self.dashboard_state_path)), exist_ok=True)
+
+        if self.verbose >= 1:
+            logger.info(
+                "MonitoringCallback initialised "
+                f"(screen_capture_freq={self.screen_capture_freq} episodes, "
+                f"dashboard_state={self.dashboard_state_path})"
+            )
+
+    # ------------------------------------------------------------------
+    # SB3 callback interface
+    # ------------------------------------------------------------------
+
+    def _on_step(self) -> bool:
+        """Detect episode endings and record per-episode stats."""
+        dones = self.locals.get("dones")
+        infos = self.locals.get("infos")
+        if dones is None or infos is None:
+            return True
+
+        for done, info in zip(dones, infos):
+            if not done:
+                continue
+            self._record_episode(info)
+
+        return True
+
+    def _on_rollout_end(self) -> None:
+        """Base class handles aggregate metrics; we add the extras."""
+        super()._on_rollout_end()
+
+        # Throttle extras at the same rate as base metrics
+        if self._rollout_count % self.log_freq != 0:
+            return
+
+        self._log_extras()
+        self._write_dashboard_state()
+
+    # ------------------------------------------------------------------
+    # Episode recording
+    # ------------------------------------------------------------------
+
+    def _record_episode(self, info: Dict[str, Any]) -> None:
+        self._episode_count += 1
+        self._episodes_since_screen += 1
+
+        ep_info = info.get("episode") or {}
+        reward = float(ep_info.get("r", 0.0))
+        length = int(ep_info.get("l", 0))
+
+        # Custom keys from PokemonRedGymEnv._get_info()
+        unique_maps = info.get("unique_maps_list") or []
+        event_progress = info.get("event_progress") or {}
+        final_map = int(info.get("current_map", 0) or 0)
+        badges = int(info.get("badges_earned", 0) or 0)
+        locations = int(info.get("locations_visited", 0) or 0)
+        triggered_names = list(event_progress.get("triggered_names", []) or [])
+        flags_triggered = int(event_progress.get("flags_triggered", len(triggered_names)))
+
+        # Update cumulative counts
+        for map_id in unique_maps:
+            try:
+                self._map_visit_counts[int(map_id)] += 1
+            except (TypeError, ValueError):
+                continue
+
+        for flag_name in triggered_names:
+            self._flag_trigger_counts[flag_name] += 1
+            self._flag_first_triggered.setdefault(flag_name, self._episode_count)
+
+        self._episode_rows.append(
+            {
+                "episode": self._episode_count,
+                "global_step": int(self.num_timesteps),
+                "reward": reward,
+                "length": length,
+                "maps_visited": len(unique_maps),
+                "final_map": final_map,
+                "badges": badges,
+                "event_flags_triggered": flags_triggered,
+                "locations_visited": locations,
+                "triggered_flags": triggered_names,
+            }
+        )
+
+        # Screen capture on schedule (at episode boundary)
+        if (
+            self.screen_capture_freq > 0
+            and self._episodes_since_screen >= self.screen_capture_freq
+        ):
+            self._log_screen_capture()
+            self._episodes_since_screen = 0
+
+    # ------------------------------------------------------------------
+    # Screen capture
+    # ------------------------------------------------------------------
+
+    def _log_screen_capture(self) -> None:
+        """Capture the current game screen and log as a W&B image."""
+        screen = self._get_env_screen()
+        if screen is None:
+            return
+
+        try:
+            img = self._wandb.Image(
+                screen,
+                caption=f"episode {self._episode_count} | step {self.num_timesteps}",
+            )
+            self._wandb.log(
+                {"game/screen": img},
+                step=self.num_timesteps,
+            )
+        except Exception as exc:
+            logger.debug(f"W&B screen log failed: {exc}")
+
+    def _get_env_screen(self) -> Optional[np.ndarray]:
+        """Fetch the first env's screen as (H, W, 3) uint8, or None."""
+        env = getattr(self, "training_env", None)
+        if env is None:
+            return None
+
+        try:
+            screens = env.env_method("render", "rgb_array", indices=[0])
+        except Exception:
+            try:
+                screens = env.env_method("render", indices=[0])
+            except Exception as exc:
+                logger.debug(f"env_method('render') failed: {exc}")
+                return None
+
+        if not screens:
+            return None
+        arr = screens[0]
+        if arr is None or not isinstance(arr, np.ndarray):
+            return None
+        if arr.dtype != np.uint8:
+            arr = np.clip(arr, 0, 255).astype(np.uint8)
+        return arr
+
+    # ------------------------------------------------------------------
+    # Extras logging
+    # ------------------------------------------------------------------
+
+    def _log_extras(self) -> None:
+        """Log heatmap, flag progress, and per-episode table to W&B."""
+        try:
+            self._log_map_heatmap()
+        except Exception as exc:
+            logger.debug(f"Map heatmap log failed: {exc}")
+
+        try:
+            self._log_flag_progress()
+        except Exception as exc:
+            logger.debug(f"Flag progress log failed: {exc}")
+
+        try:
+            self._log_episode_table()
+        except Exception as exc:
+            logger.debug(f"Episode table log failed: {exc}")
+
+    def _log_map_heatmap(self) -> None:
+        if not self._map_visit_counts:
+            return
+
+        rows = sorted(self._map_visit_counts.items())
+        table = self._wandb.Table(columns=["map_id", "visit_count"])
+        for map_id, count in rows:
+            table.add_data(int(map_id), int(count))
+
+        payload: Dict[str, Any] = {"game/map_heatmap_table": table}
+
+        chart = self._render_map_heatmap_chart(rows)
+        if chart is not None:
+            payload["game/map_heatmap"] = self._wandb.Image(
+                chart,
+                caption=f"Map visit counts (cumulative, step {self.num_timesteps})",
+            )
+
+        self._wandb.log(payload, step=self.num_timesteps)
+
+    @staticmethod
+    def _render_map_heatmap_chart(rows: List[tuple]) -> Optional[np.ndarray]:
+        """Render a simple horizontal-bar chart of map visit counts."""
+        if not rows:
+            return None
+
+        try:
+            map_ids = [str(r[0]) for r in rows]
+            counts = [r[1] for r in rows]
+
+            fig, ax = plt.subplots(figsize=(6, max(2.5, 0.25 * len(rows))))
+            ax.barh(map_ids, counts, color="#3b82f6")
+            ax.set_xlabel("Episodes that visited map")
+            ax.set_ylabel("map_id")
+            ax.set_title("Map exploration heatmap")
+            ax.invert_yaxis()
+            fig.tight_layout()
+
+            fig.canvas.draw()
+            img = np.asarray(fig.canvas.buffer_rgba())[..., :3].copy()
+            plt.close(fig)
+            return img
+        except Exception as exc:
+            logger.debug(f"Heatmap render failed: {exc}")
+            return None
+
+    def _log_flag_progress(self) -> None:
+        try:
+            from ..game.event_flags import BOULDER_PATH_FLAGS
+        except Exception as exc:
+            logger.debug(f"Cannot import BOULDER_PATH_FLAGS: {exc}")
+            return
+
+        table = self._wandb.Table(
+            columns=["flag_name", "trigger_count", "first_triggered_episode"]
+        )
+        for flag_name in BOULDER_PATH_FLAGS:
+            count = int(self._flag_trigger_counts.get(flag_name, 0))
+            first = self._flag_first_triggered.get(flag_name, -1)
+            table.add_data(flag_name, count, int(first))
+
+        metrics: Dict[str, Any] = {"game/flag_progress": table}
+
+        total_flags = len(BOULDER_PATH_FLAGS)
+        unique_flags_ever = sum(
+            1 for n in BOULDER_PATH_FLAGS if self._flag_trigger_counts.get(n, 0) > 0
+        )
+        metrics["game/unique_flags_ever"] = unique_flags_ever
+        metrics["game/unique_flags_fraction"] = (
+            unique_flags_ever / total_flags if total_flags else 0.0
+        )
+
+        self._wandb.log(metrics, step=self.num_timesteps)
+
+    def _log_episode_table(self) -> None:
+        if not self._episode_rows:
+            return
+
+        table = self._wandb.Table(
+            columns=[
+                "episode",
+                "global_step",
+                "reward",
+                "length",
+                "maps_visited",
+                "final_map",
+                "badges",
+                "event_flags_triggered",
+                "locations_visited",
+            ]
+        )
+        for row in self._episode_rows[-500:]:  # cap to avoid huge payloads
+            table.add_data(
+                row["episode"],
+                row["global_step"],
+                row["reward"],
+                row["length"],
+                row["maps_visited"],
+                row["final_map"],
+                row["badges"],
+                row["event_flags_triggered"],
+                row["locations_visited"],
+            )
+        self._wandb.log(
+            {"game/episodes": table},
+            step=self.num_timesteps,
+        )
+
+    # ------------------------------------------------------------------
+    # Dashboard JSON snapshot
+    # ------------------------------------------------------------------
+
+    def _write_dashboard_state(self) -> None:
+        """Mirror monitoring state to a JSON file for local dashboards.
+
+        Overwrites the file atomically so readers never see a partial
+        write.  Failures are swallowed (logged at DEBUG) — the snapshot
+        is best-effort.
+        """
+        try:
+            from ..game.event_flags import BOULDER_PATH_FLAGS
+            flag_names = list(BOULDER_PATH_FLAGS)
+        except Exception:
+            flag_names = list(self._flag_trigger_counts)
+
+        snapshot = {
+            "num_timesteps": int(self.num_timesteps),
+            "episode_count": self._episode_count,
+            "best_reward": (
+                self.best_reward if self.best_reward != -float("inf") else None
+            ),
+            "map_visit_counts": {
+                str(k): int(v) for k, v in self._map_visit_counts.items()
+            },
+            "flag_trigger_counts": {
+                name: int(self._flag_trigger_counts.get(name, 0))
+                for name in flag_names
+            },
+            "flag_first_triggered": {
+                name: int(self._flag_first_triggered.get(name, -1))
+                for name in flag_names
+            },
+            "episodes": self._episode_rows[-200:],
+        }
+
+        try:
+            tmp_path = self.dashboard_state_path + ".tmp"
+            with open(tmp_path, "w", encoding="utf-8") as fh:
+                json.dump(snapshot, fh, indent=2)
+            os.replace(tmp_path, self.dashboard_state_path)
+        except Exception as exc:
+            logger.debug(f"Dashboard state write failed: {exc}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,14 @@ Homepage = "https://github.com/amcheste/pokemon-red-ai"
 Repository = "https://github.com/amcheste/pokemon-red-ai"
 Issues = "https://github.com/amcheste/pokemon-red-ai/issues"
 
+[project.optional-dependencies]
+# Install with: pip install -e ".[dashboard]"
+# Only needed to run ``scripts/monitor.py`` — training itself does not
+# depend on Streamlit.
+dashboard = [
+    "streamlit>=1.28",
+]
+
 [project.scripts]
 pokemon-ai = "pokemon_red_ai.cli.commands:main"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,3 +52,8 @@ typing_extensions==4.15.0
 tzdata==2025.2
 wandb==0.18.7
 Werkzeug==3.1.3
+
+# Optional: training monitor dashboard (scripts/monitor.py).  Also
+# available via ``pip install -e ".[dashboard]"``.  Comment out if you
+# don't need the Streamlit UI.
+streamlit==1.40.1

--- a/scripts/monitor.py
+++ b/scripts/monitor.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""
+Pokemon Red RL training monitor dashboard (local, no W&B required).
+
+Reads the ``dashboard_state.json`` snapshots and Monitor CSVs written by
+:class:`MonitoringCallback` (see ``pokemon_red_ai/training/callbacks.py``)
+and renders a Streamlit dashboard that helps a researcher decide whether
+a run is worth continuing.
+
+Usage::
+
+    # Point at one or more training output dirs (the ``--save-dir``
+    # passed to ``scripts/train.py``).  Each dir must contain
+    # ``dashboard_state.json`` and/or ``monitor.csv``.
+    streamlit run scripts/monitor.py -- --runs-dir ./training_output
+
+Features:
+- Live reward curves (per-episode, from ``monitor.csv``)
+- Map exploration grid (from ``dashboard_state.json``)
+- Event flag checklist — 18 pre-registered Boulder Path flags
+- Run comparison: pick multiple save dirs to overlay curves
+- Optional TensorBoard scalar overlay (``rollout/ep_rew_mean``) if
+  ``tensorboard`` is installed
+
+The helper functions (``load_dashboard_state``, ``load_monitor_csv``,
+``discover_runs``) are module-level so tests can exercise them without
+launching Streamlit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+
+# Make ``pokemon_red_ai`` importable when invoked as a script.
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from pokemon_red_ai.game.event_flags import BOULDER_PATH_FLAGS  # noqa: E402
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Data loading helpers
+# ──────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class RunData:
+    """All monitoring data for a single training run."""
+
+    name: str
+    path: Path
+    dashboard_state: Optional[Dict[str, Any]] = None
+    monitor_df: Optional[pd.DataFrame] = None
+    tensorboard_scalars: Optional[Dict[str, pd.DataFrame]] = None
+
+    @property
+    def episode_count(self) -> int:
+        if self.dashboard_state is not None:
+            return int(self.dashboard_state.get("episode_count", 0))
+        if self.monitor_df is not None:
+            return len(self.monitor_df)
+        return 0
+
+    @property
+    def num_timesteps(self) -> int:
+        if self.dashboard_state is not None:
+            return int(self.dashboard_state.get("num_timesteps", 0))
+        return 0
+
+    @property
+    def best_reward(self) -> Optional[float]:
+        if self.dashboard_state is not None:
+            return self.dashboard_state.get("best_reward")
+        if self.monitor_df is not None and "r" in self.monitor_df:
+            return float(self.monitor_df["r"].max())
+        return None
+
+
+def discover_runs(runs_dir: Path) -> List[Path]:
+    """Return subdirectories of ``runs_dir`` that look like training runs.
+
+    A directory qualifies if it contains either a ``dashboard_state.json``
+    or a ``monitor.csv.monitor.csv`` (SB3's default naming when passing
+    a basename without ``.csv``).  The single ``runs_dir`` itself also
+    qualifies if it looks like a run — useful when the user points at a
+    single ``--save-dir`` directly.
+    """
+    if not runs_dir.exists():
+        return []
+
+    candidates: List[Path] = []
+    if _is_run_dir(runs_dir):
+        candidates.append(runs_dir)
+
+    for child in sorted(runs_dir.iterdir()):
+        if child.is_dir() and _is_run_dir(child):
+            candidates.append(child)
+
+    return candidates
+
+
+def _is_run_dir(path: Path) -> bool:
+    if (path / "dashboard_state.json").exists():
+        return True
+    # SB3 Monitor writes to ``<path>/monitor.monitor.csv`` when the
+    # caller passes ``<path>/monitor`` as the filename.
+    if any(path.glob("monitor*.csv")):
+        return True
+    if (path / "tensorboard").exists():
+        return True
+    return False
+
+
+def load_dashboard_state(run_dir: Path) -> Optional[Dict[str, Any]]:
+    """Load the JSON snapshot written by :class:`MonitoringCallback`.
+
+    Returns ``None`` if the file is missing or malformed.
+    """
+    state_file = run_dir / "dashboard_state.json"
+    if not state_file.exists():
+        return None
+    try:
+        with state_file.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def load_monitor_csv(run_dir: Path) -> Optional[pd.DataFrame]:
+    """Load SB3 Monitor-wrapper CSV into a DataFrame.
+
+    Adds a cumulative ``episode`` index column for plotting.
+    Returns ``None`` if no monitor CSV exists or it is empty.
+    """
+    csv_paths = sorted(run_dir.glob("monitor*.csv"))
+    if not csv_paths:
+        return None
+
+    try:
+        df = pd.read_csv(csv_paths[0], comment="#")
+    except (OSError, pd.errors.EmptyDataError, pd.errors.ParserError):
+        return None
+
+    if df.empty:
+        return None
+
+    df = df.reset_index(drop=True)
+    df["episode"] = df.index + 1
+    if "l" in df.columns:
+        df["cumulative_steps"] = df["l"].cumsum()
+    return df
+
+
+def load_tensorboard_scalars(
+    run_dir: Path,
+    tags: Optional[List[str]] = None,
+) -> Optional[Dict[str, pd.DataFrame]]:
+    """Load scalar series from TensorBoard event files, if available.
+
+    ``tags`` filters which scalars to return (default: all).  Returns
+    ``None`` if TensorBoard isn't installed or no event files exist.
+    """
+    try:
+        from tensorboard.backend.event_processing.event_accumulator import (
+            EventAccumulator,
+        )
+    except ImportError:
+        return None
+
+    tb_dir = run_dir / "tensorboard"
+    if not tb_dir.exists():
+        return None
+
+    event_files = list(tb_dir.rglob("events.out.tfevents.*"))
+    if not event_files:
+        return None
+
+    scalars: Dict[str, pd.DataFrame] = {}
+    seen_dirs = {event_file.parent for event_file in event_files}
+    for event_dir in seen_dirs:
+        try:
+            acc = EventAccumulator(str(event_dir))
+            acc.Reload()
+        except Exception:
+            continue
+
+        available = acc.Tags().get("scalars", [])
+        wanted = [t for t in available if (tags is None or t in tags)]
+        for tag in wanted:
+            try:
+                events = acc.Scalars(tag)
+            except KeyError:
+                continue
+            df = pd.DataFrame(
+                {
+                    "step": [e.step for e in events],
+                    "value": [e.value for e in events],
+                    "wall_time": [e.wall_time for e in events],
+                }
+            )
+            scalars[tag] = df
+
+    return scalars or None
+
+
+def load_run(run_dir: Path) -> RunData:
+    """Load all available monitoring data for a run directory."""
+    return RunData(
+        name=run_dir.name or str(run_dir),
+        path=run_dir,
+        dashboard_state=load_dashboard_state(run_dir),
+        monitor_df=load_monitor_csv(run_dir),
+        tensorboard_scalars=load_tensorboard_scalars(run_dir),
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Metric helpers
+# ──────────────────────────────────────────────────────────────────────
+
+
+def reward_curve_df(run: RunData) -> Optional[pd.DataFrame]:
+    """Return a DataFrame with ``episode``, ``reward``, and a moving average."""
+    if run.monitor_df is None or "r" not in run.monitor_df.columns:
+        return None
+
+    df = run.monitor_df[["episode", "r"]].copy()
+    df = df.rename(columns={"r": "reward"})
+    window = max(1, min(20, len(df) // 5 or 1))
+    df["reward_avg"] = df["reward"].rolling(window=window, min_periods=1).mean()
+    return df
+
+
+def flag_progress_df(run: RunData) -> pd.DataFrame:
+    """Return one row per pre-registered Boulder Path flag.
+
+    Rows always include all 18 flags even if ``dashboard_state`` is
+    unavailable — the dashboard should show the full checklist.
+    """
+    state = run.dashboard_state or {}
+    trigger_counts: Dict[str, int] = state.get("flag_trigger_counts", {}) or {}
+    first_triggered: Dict[str, int] = state.get("flag_first_triggered", {}) or {}
+
+    rows = []
+    for name in BOULDER_PATH_FLAGS:
+        count = int(trigger_counts.get(name, 0))
+        first = int(first_triggered.get(name, -1))
+        rows.append(
+            {
+                "flag": name,
+                "triggered": count > 0,
+                "count": count,
+                "first_episode": first if first > 0 else None,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def map_heatmap_df(run: RunData) -> Optional[pd.DataFrame]:
+    """Return a DataFrame with ``map_id`` and ``visit_count`` columns."""
+    state = run.dashboard_state
+    if not state:
+        return None
+    counts = state.get("map_visit_counts") or {}
+    if not counts:
+        return None
+    rows = sorted(((int(k), int(v)) for k, v in counts.items()), key=lambda x: x[0])
+    return pd.DataFrame(rows, columns=["map_id", "visit_count"])
+
+
+def episode_breakdown_df(run: RunData) -> Optional[pd.DataFrame]:
+    """Return per-episode rows from dashboard_state (or None)."""
+    state = run.dashboard_state
+    if not state:
+        return None
+    episodes = state.get("episodes") or []
+    if not episodes:
+        return None
+    df = pd.DataFrame(episodes)
+    if "triggered_flags" in df.columns:
+        df["triggered_flags"] = df["triggered_flags"].apply(
+            lambda v: ", ".join(v) if isinstance(v, list) else ""
+        )
+    return df
+
+
+def run_summary(run: RunData) -> Dict[str, Any]:
+    """Return a small dict of headline metrics for the sidebar."""
+    summary: Dict[str, Any] = {
+        "run": run.name,
+        "episodes": run.episode_count,
+        "steps": run.num_timesteps,
+        "best_reward": run.best_reward,
+    }
+
+    flags = flag_progress_df(run)
+    summary["flags_triggered"] = int(flags["triggered"].sum())
+    summary["flags_total"] = len(flags)
+
+    heatmap = map_heatmap_df(run)
+    summary["maps_discovered"] = 0 if heatmap is None else len(heatmap)
+
+    return summary
+
+
+# ──────────────────────────────────────────────────────────────────────
+# CLI parser — used both for ``streamlit run`` and headless testing
+# ──────────────────────────────────────────────────────────────────────
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--runs-dir",
+        type=str,
+        default="./training_output",
+        help="Root directory of training runs (or a single --save-dir).",
+    )
+    return p
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse Streamlit-forwarded CLI args (after ``--``)."""
+    parser = build_parser()
+    # Streamlit forwards the script's argv verbatim, so args after '--'
+    # are available here.
+    return parser.parse_args()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Streamlit app
+# ──────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    import streamlit as st  # imported here so tests don't need streamlit
+
+    args = _parse_args()
+
+    st.set_page_config(
+        page_title="Pokemon Red RL — Training Monitor",
+        layout="wide",
+    )
+    st.title("Pokemon Red RL — Training Monitor")
+    st.caption(
+        "Live view of training runs — reward curves, map exploration, "
+        "and the 18 Boulder-Path event flags."
+    )
+
+    runs_root = Path(args.runs_dir).expanduser().resolve()
+    candidates = discover_runs(runs_root)
+
+    if not candidates:
+        st.warning(
+            f"No training runs found under `{runs_root}`. "
+            "Pass `--runs-dir` pointing at a `--save-dir` from "
+            "`scripts/train.py`."
+        )
+        return
+
+    with st.sidebar:
+        st.header("Runs")
+        st.write(f"Root: `{runs_root}`")
+
+        default_selection = [candidates[-1].name]
+        selected_names = st.multiselect(
+            "Select runs to display",
+            options=[c.name for c in candidates],
+            default=default_selection,
+        )
+
+        st.caption(
+            "Tip: select multiple runs to overlay reward curves "
+            "(e.g. different seeds)."
+        )
+
+        refresh = st.button("Refresh data")
+        if refresh:
+            st.rerun()
+
+    selected_runs: List[RunData] = [
+        load_run(c) for c in candidates if c.name in selected_names
+    ]
+
+    if not selected_runs:
+        st.info("Pick at least one run in the sidebar.")
+        return
+
+    # ── Headline metrics ─────────────────────────────────────────────
+    st.subheader("Headline metrics")
+    cols = st.columns(len(selected_runs))
+    for col, run in zip(cols, selected_runs):
+        summary = run_summary(run)
+        with col:
+            st.metric(label=run.name, value=f"{summary['episodes']} episodes")
+            st.write(f"**Steps:** {summary['steps']:,}")
+            st.write(
+                f"**Best reward:** "
+                f"{'—' if summary['best_reward'] is None else f'{summary["best_reward"]:.1f}'}"
+            )
+            st.write(
+                f"**Flags:** {summary['flags_triggered']}/{summary['flags_total']}"
+            )
+            st.write(f"**Maps:** {summary['maps_discovered']}")
+
+    # ── Reward curves ────────────────────────────────────────────────
+    st.subheader("Episode reward")
+    reward_series = {}
+    for run in selected_runs:
+        df = reward_curve_df(run)
+        if df is not None:
+            reward_series[run.name] = df.set_index("episode")["reward_avg"]
+
+    if reward_series:
+        chart_df = pd.concat(reward_series, axis=1)
+        st.line_chart(chart_df, height=320)
+    else:
+        st.caption("No monitor.csv found for any selected run.")
+
+    # ── Map exploration ──────────────────────────────────────────────
+    st.subheader("Map exploration")
+    map_cols = st.columns(len(selected_runs))
+    for col, run in zip(map_cols, selected_runs):
+        with col:
+            st.caption(run.name)
+            heatmap = map_heatmap_df(run)
+            if heatmap is None:
+                st.write("No map data yet.")
+            else:
+                st.bar_chart(
+                    heatmap.set_index("map_id")["visit_count"],
+                    height=220,
+                )
+                st.dataframe(heatmap, use_container_width=True, hide_index=True)
+
+    # ── Event flag checklist ─────────────────────────────────────────
+    st.subheader("Event flag checklist (Boulder Path)")
+    flag_cols = st.columns(len(selected_runs))
+    for col, run in zip(flag_cols, selected_runs):
+        with col:
+            st.caption(run.name)
+            flags = flag_progress_df(run)
+            triggered_count = int(flags["triggered"].sum())
+            total = len(flags)
+            st.progress(triggered_count / max(total, 1))
+            st.write(f"{triggered_count}/{total} flags triggered")
+            st.dataframe(
+                flags[["flag", "triggered", "count", "first_episode"]],
+                use_container_width=True,
+                hide_index=True,
+            )
+
+    # ── Per-episode breakdown ────────────────────────────────────────
+    st.subheader("Per-episode breakdown")
+    for run in selected_runs:
+        ep_df = episode_breakdown_df(run)
+        if ep_df is None:
+            continue
+        with st.expander(f"{run.name} — last {len(ep_df)} episodes", expanded=False):
+            st.dataframe(ep_df, use_container_width=True, hide_index=True)
+
+    # ── Optional TB overlay ──────────────────────────────────────────
+    tb_any = any(r.tensorboard_scalars for r in selected_runs)
+    if tb_any:
+        st.subheader("TensorBoard scalars (rollout/ep_rew_mean)")
+        tb_series = {}
+        for run in selected_runs:
+            if not run.tensorboard_scalars:
+                continue
+            df = run.tensorboard_scalars.get("rollout/ep_rew_mean")
+            if df is not None and not df.empty:
+                tb_series[run.name] = df.set_index("step")["value"]
+        if tb_series:
+            st.line_chart(pd.concat(tb_series, axis=1), height=260)
+        else:
+            st.caption("No `rollout/ep_rew_mean` scalar yet.")
+
+    st.caption(
+        "Is this run worth continuing? Look for: rising reward curve, "
+        "new maps appearing, and flags ticking on in order."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -49,7 +49,8 @@ from pokemon_red_ai.training.models import (
 )
 from pokemon_red_ai.training.callbacks import (
     TrainingCallback,
-    WandbCallback,
+    MonitoringCallback,
+    MONITORED_INFO_KEYS,
 )
 from pokemon_red_ai.utils import create_directories
 
@@ -156,6 +157,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--no-wandb", action="store_true",
         help="Disable W&B logging entirely.",
     )
+    p.add_argument(
+        "--screen-capture-freq", type=int, default=10,
+        help="Episodes between game-screen captures logged to W&B. 0 disables.",
+    )
 
     # ── Misc ─────────────────────────────────────────────────────────
     p.add_argument(
@@ -231,7 +236,14 @@ def train(args: argparse.Namespace) -> None:
         observation_type=args.observation_type,
         save_state_path=args.save_state,
     )
-    env = Monitor(env, os.path.join(args.save_dir, "monitor"))
+    # ``info_keywords`` makes Monitor copy our custom per-step metrics
+    # into ``ep_info_buffer``, which is what the W&B callback reads for
+    # aggregate episode stats (maps_visited mean, badges_max, etc.).
+    env = Monitor(
+        env,
+        os.path.join(args.save_dir, "monitor"),
+        info_keywords=MONITORED_INFO_KEYS,
+    )
 
     logger.info(
         f"Environment ready  "
@@ -330,9 +342,10 @@ def train(args: argparse.Namespace) -> None:
 
     if wandb_run is not None:
         callbacks.append(
-            WandbCallback(
+            MonitoringCallback(
                 save_freq=args.save_freq,
                 save_path=args.save_dir,
+                screen_capture_freq=args.screen_capture_freq,
                 verbose=1,
             )
         )

--- a/tests/unit/test_monitor_script.py
+++ b/tests/unit/test_monitor_script.py
@@ -1,0 +1,251 @@
+"""
+Unit tests for scripts/monitor.py — Streamlit training dashboard.
+
+These tests exercise only the pure-data helpers (``load_dashboard_state``,
+``load_monitor_csv``, ``discover_runs``, etc.).  The Streamlit UI is
+imported lazily inside ``main()``, so the module can be imported without
+Streamlit installed.
+"""
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from scripts.monitor import (
+    discover_runs,
+    episode_breakdown_df,
+    flag_progress_df,
+    load_dashboard_state,
+    load_monitor_csv,
+    load_run,
+    map_heatmap_df,
+    reward_curve_df,
+    run_summary,
+)
+from pokemon_red_ai.game.event_flags import BOULDER_PATH_FLAGS
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fixtures
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def run_dir(tmp_path):
+    """Create a minimal run dir with dashboard_state.json and monitor.csv."""
+    run = tmp_path / "rppo-events-seed42"
+    run.mkdir()
+
+    state = {
+        "num_timesteps": 10_000,
+        "episode_count": 3,
+        "best_reward": 150.5,
+        "map_visit_counts": {"1": 3, "2": 2, "40": 1},
+        "flag_trigger_counts": {
+            "EVENT_GOT_STARTER": 2,
+            "EVENT_FOLLOWED_OAK_INTO_LAB": 3,
+        },
+        "flag_first_triggered": {
+            "EVENT_GOT_STARTER": 2,
+            "EVENT_FOLLOWED_OAK_INTO_LAB": 1,
+        },
+        "episodes": [
+            {
+                "episode": 1,
+                "global_step": 1000,
+                "reward": 5.0,
+                "length": 200,
+                "maps_visited": 1,
+                "final_map": 1,
+                "badges": 0,
+                "event_flags_triggered": 1,
+                "locations_visited": 20,
+                "triggered_flags": ["EVENT_FOLLOWED_OAK_INTO_LAB"],
+            },
+            {
+                "episode": 2,
+                "global_step": 5000,
+                "reward": 50.0,
+                "length": 400,
+                "maps_visited": 2,
+                "final_map": 2,
+                "badges": 0,
+                "event_flags_triggered": 2,
+                "locations_visited": 60,
+                "triggered_flags": [
+                    "EVENT_FOLLOWED_OAK_INTO_LAB",
+                    "EVENT_GOT_STARTER",
+                ],
+            },
+            {
+                "episode": 3,
+                "global_step": 10_000,
+                "reward": 150.5,
+                "length": 600,
+                "maps_visited": 3,
+                "final_map": 40,
+                "badges": 1,
+                "event_flags_triggered": 2,
+                "locations_visited": 120,
+                "triggered_flags": [
+                    "EVENT_FOLLOWED_OAK_INTO_LAB",
+                    "EVENT_GOT_STARTER",
+                ],
+            },
+        ],
+    }
+    (run / "dashboard_state.json").write_text(json.dumps(state))
+
+    # Minimal SB3 Monitor CSV (one comment line + header + rows)
+    csv_content = (
+        '#{"t_start": 1.0, "env_id": null}\n'
+        "r,l,t\n"
+        "5.0,200,1.5\n"
+        "50.0,400,2.5\n"
+        "150.5,600,3.5\n"
+    )
+    (run / "monitor.monitor.csv").write_text(csv_content)
+
+    return run
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Discovery
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestDiscoverRuns:
+    def test_finds_single_run_passed_directly(self, run_dir):
+        runs = discover_runs(run_dir)
+        assert run_dir in runs
+
+    def test_finds_child_runs_under_root(self, tmp_path, run_dir):
+        # run_dir is a child of tmp_path
+        runs = discover_runs(tmp_path)
+        assert run_dir in runs
+
+    def test_missing_dir(self, tmp_path):
+        assert discover_runs(tmp_path / "nope") == []
+
+    def test_ignores_non_run_dirs(self, tmp_path):
+        (tmp_path / "empty").mkdir()
+        (tmp_path / "random_file.txt").write_text("hi")
+        assert discover_runs(tmp_path) == []
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Loaders
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestLoaders:
+    def test_load_dashboard_state(self, run_dir):
+        state = load_dashboard_state(run_dir)
+        assert state is not None
+        assert state["num_timesteps"] == 10_000
+        assert state["episode_count"] == 3
+
+    def test_load_dashboard_state_missing(self, tmp_path):
+        assert load_dashboard_state(tmp_path) is None
+
+    def test_load_dashboard_state_malformed(self, tmp_path):
+        (tmp_path / "dashboard_state.json").write_text("{not json")
+        assert load_dashboard_state(tmp_path) is None
+
+    def test_load_monitor_csv(self, run_dir):
+        df = load_monitor_csv(run_dir)
+        assert df is not None
+        assert len(df) == 3
+        assert "r" in df.columns
+        assert list(df["episode"]) == [1, 2, 3]
+        assert df["cumulative_steps"].iloc[-1] == 1200
+
+    def test_load_monitor_csv_missing(self, tmp_path):
+        assert load_monitor_csv(tmp_path) is None
+
+    def test_load_run_aggregates(self, run_dir):
+        run = load_run(run_dir)
+        assert run.episode_count == 3
+        assert run.num_timesteps == 10_000
+        assert run.best_reward == pytest.approx(150.5)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# DataFrame builders
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestDataFrameBuilders:
+    def test_reward_curve_df(self, run_dir):
+        run = load_run(run_dir)
+        df = reward_curve_df(run)
+        assert df is not None
+        assert "reward" in df.columns
+        assert "reward_avg" in df.columns
+        assert len(df) == 3
+
+    def test_reward_curve_df_no_monitor(self, tmp_path):
+        run = load_run(tmp_path)
+        assert reward_curve_df(run) is None
+
+    def test_flag_progress_df_shows_all_18(self, run_dir):
+        run = load_run(run_dir)
+        df = flag_progress_df(run)
+        assert len(df) == 18
+        # Must include the untriggered flags too
+        triggered = df[df["triggered"]]["flag"].tolist()
+        assert "EVENT_GOT_STARTER" in triggered
+        assert "EVENT_BEAT_BROCK" not in triggered
+
+    def test_flag_progress_df_without_state(self, tmp_path):
+        run = load_run(tmp_path)
+        df = flag_progress_df(run)
+        # Still lists all 18 flags even with no data
+        assert len(df) == 18
+        assert df["triggered"].sum() == 0
+
+    def test_map_heatmap_df(self, run_dir):
+        run = load_run(run_dir)
+        df = map_heatmap_df(run)
+        assert df is not None
+        assert len(df) == 3
+        # Sorted by map_id
+        assert list(df["map_id"]) == [1, 2, 40]
+
+    def test_episode_breakdown_df(self, run_dir):
+        run = load_run(run_dir)
+        df = episode_breakdown_df(run)
+        assert df is not None
+        assert len(df) == 3
+        assert "triggered_flags" in df.columns
+        # triggered_flags list is stringified for display
+        assert all(isinstance(v, str) for v in df["triggered_flags"])
+
+    def test_run_summary(self, run_dir):
+        run = load_run(run_dir)
+        summary = run_summary(run)
+        assert summary["episodes"] == 3
+        assert summary["steps"] == 10_000
+        assert summary["best_reward"] == pytest.approx(150.5)
+        assert summary["flags_triggered"] == 2
+        assert summary["flags_total"] == len(BOULDER_PATH_FLAGS)
+        assert summary["maps_discovered"] == 3
+
+
+# ──────────────────────────────────────────────────────────────────────
+# CLI parser
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestBuildParser:
+    def test_default_runs_dir(self):
+        from scripts.monitor import build_parser
+        args = build_parser().parse_args([])
+        assert args.runs_dir == "./training_output"
+
+    def test_custom_runs_dir(self):
+        from scripts.monitor import build_parser
+        args = build_parser().parse_args(["--runs-dir", "/tmp/foo"])
+        assert args.runs_dir == "/tmp/foo"

--- a/tests/unit/training/test_monitoring_callback.py
+++ b/tests/unit/training/test_monitoring_callback.py
@@ -1,0 +1,356 @@
+"""
+Unit tests for MonitoringCallback.
+
+Covers the monitoring-specific extensions that aren't exercised by
+``test_wandb_callback.py``: per-episode recording, map heatmap, event
+flag tracking, screen captures, and dashboard JSON snapshots.
+"""
+
+import json
+import os
+from unittest.mock import MagicMock, Mock, patch
+
+import numpy as np
+import pytest
+
+from pokemon_red_ai.training.callbacks import (
+    MONITORED_INFO_KEYS,
+    MonitoringCallback,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fixtures
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_wandb():
+    wandb = MagicMock()
+    wandb.log = Mock()
+    wandb.Image = Mock(side_effect=lambda arr, caption=None: {"img": arr, "caption": caption})
+    wandb.Table = Mock(side_effect=lambda columns: _FakeTable(columns))
+    wandb.Artifact = Mock(return_value=Mock())
+    wandb.log_artifact = Mock()
+    return wandb
+
+
+class _FakeTable:
+    """Minimal stand-in for wandb.Table so we can inspect logged rows."""
+
+    def __init__(self, columns):
+        self.columns = list(columns)
+        self.data = []
+
+    def add_data(self, *row):
+        self.data.append(row)
+
+
+@pytest.fixture
+def monitoring_cb(tmp_path, mock_wandb):
+    with patch.dict("sys.modules", {"wandb": mock_wandb}):
+        cb = MonitoringCallback(
+            save_freq=10_000,
+            save_path=str(tmp_path),
+            screen_capture_freq=2,
+            verbose=0,
+        )
+    cb._wandb = mock_wandb
+
+    # SB3 exposes ``training_env`` as a property that reads
+    # ``self.model.get_env()``, so we inject the fake env via the model.
+    fake_env = Mock()
+    fake_env.env_method = Mock(
+        return_value=[np.full((72, 80, 3), 128, dtype=np.uint8)]
+    )
+
+    model = Mock()
+    model.ep_info_buffer = []
+    model.save = Mock()
+    model.get_env = Mock(return_value=fake_env)
+    cb.model = model
+    cb.num_timesteps = 0
+    cb.n_calls = 0
+    cb.locals = {}
+    cb.globals = {}
+    return cb
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Info keyword contract
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_monitored_info_keys_present():
+    """The tuple includes the info keys the callback actually consumes."""
+    expected = {
+        "maps_visited",
+        "badges_earned",
+        "event_progress",
+        "current_map",
+        "unique_maps_list",
+    }
+    assert expected.issubset(set(MONITORED_INFO_KEYS))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Per-episode recording via _on_step
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _make_step_info(
+    reward=10.0,
+    length=100,
+    unique_maps=(1, 2),
+    triggered_flags=("EVENT_GOT_STARTER",),
+    current_map=2,
+    badges=1,
+    locations=42,
+):
+    return {
+        "episode": {"r": reward, "l": length},
+        "unique_maps_list": list(unique_maps),
+        "event_progress": {
+            "flags_triggered": len(triggered_flags),
+            "triggered_names": list(triggered_flags),
+        },
+        "current_map": current_map,
+        "badges_earned": badges,
+        "locations_visited": locations,
+    }
+
+
+class TestOnStepEpisodeTracking:
+    def test_records_completed_episode(self, monitoring_cb):
+        monitoring_cb.locals = {
+            "dones": [True],
+            "infos": [_make_step_info()],
+        }
+        monitoring_cb.num_timesteps = 500
+
+        monitoring_cb._on_step()
+
+        assert monitoring_cb._episode_count == 1
+        row = monitoring_cb._episode_rows[0]
+        assert row["reward"] == pytest.approx(10.0)
+        assert row["maps_visited"] == 2
+        assert row["final_map"] == 2
+        assert row["badges"] == 1
+        assert row["event_flags_triggered"] == 1
+        assert row["triggered_flags"] == ["EVENT_GOT_STARTER"]
+
+    def test_ignores_non_terminal_steps(self, monitoring_cb):
+        monitoring_cb.locals = {
+            "dones": [False],
+            "infos": [_make_step_info()],
+        }
+        monitoring_cb._on_step()
+        assert monitoring_cb._episode_count == 0
+
+    def test_updates_map_counts_across_episodes(self, monitoring_cb):
+        monitoring_cb.locals = {
+            "dones": [True],
+            "infos": [_make_step_info(unique_maps=(1, 2))],
+        }
+        monitoring_cb._on_step()
+
+        monitoring_cb.locals = {
+            "dones": [True],
+            "infos": [_make_step_info(unique_maps=(2, 3))],
+        }
+        monitoring_cb._on_step()
+
+        assert monitoring_cb._map_visit_counts[1] == 1
+        assert monitoring_cb._map_visit_counts[2] == 2
+        assert monitoring_cb._map_visit_counts[3] == 1
+
+    def test_first_triggered_sticks(self, monitoring_cb):
+        monitoring_cb.locals = {
+            "dones": [True],
+            "infos": [_make_step_info(triggered_flags=("EVENT_GOT_STARTER",))],
+        }
+        monitoring_cb._on_step()
+
+        # Episode 2 triggers same flag — first_triggered should stay at 1
+        monitoring_cb.locals = {
+            "dones": [True],
+            "infos": [_make_step_info(triggered_flags=("EVENT_GOT_STARTER",))],
+        }
+        monitoring_cb._on_step()
+
+        assert monitoring_cb._flag_trigger_counts["EVENT_GOT_STARTER"] == 2
+        assert monitoring_cb._flag_first_triggered["EVENT_GOT_STARTER"] == 1
+
+    def test_missing_info_does_not_crash(self, monitoring_cb):
+        monitoring_cb.locals = {"dones": [True], "infos": [{}]}
+        monitoring_cb._on_step()
+        assert monitoring_cb._episode_count == 1
+        row = monitoring_cb._episode_rows[0]
+        assert row["reward"] == 0.0
+        assert row["maps_visited"] == 0
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Screen captures
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestScreenCapture:
+    def test_fires_on_schedule(self, monitoring_cb, mock_wandb):
+        monitoring_cb.screen_capture_freq = 2
+
+        # Episode 1 — no capture
+        monitoring_cb.locals = {"dones": [True], "infos": [_make_step_info()]}
+        monitoring_cb._on_step()
+
+        # Episode 2 — capture fires
+        monitoring_cb.locals = {"dones": [True], "infos": [_make_step_info()]}
+        monitoring_cb._on_step()
+
+        image_logs = [
+            call for call in mock_wandb.log.call_args_list
+            if "game/screen" in call.args[0]
+        ]
+        assert len(image_logs) == 1
+        mock_wandb.Image.assert_called()
+
+    def test_disable_with_zero_freq(self, tmp_path, mock_wandb):
+        with patch.dict("sys.modules", {"wandb": mock_wandb}):
+            cb = MonitoringCallback(
+                save_path=str(tmp_path),
+                screen_capture_freq=0,
+                verbose=0,
+            )
+        cb._wandb = mock_wandb
+
+        fake_env = Mock()
+        fake_env.env_method = Mock()
+        cb.model = Mock(
+            ep_info_buffer=[],
+            save=Mock(),
+            get_env=Mock(return_value=fake_env),
+        )
+        cb.num_timesteps = 0
+        cb.n_calls = 0
+        cb.locals = {"dones": [True], "infos": [_make_step_info()]}
+        cb.globals = {}
+
+        cb._on_step()
+
+        # env_method should never be called when freq=0
+        fake_env.env_method.assert_not_called()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Extras logging (heatmap / flags / episode table)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestRolloutEndExtras:
+    def _populate(self, cb):
+        cb.locals = {"dones": [True], "infos": [_make_step_info()]}
+        cb._on_step()
+
+    def test_logs_map_heatmap_table(self, monitoring_cb, mock_wandb):
+        self._populate(monitoring_cb)
+        monitoring_cb.num_timesteps = 2048
+        monitoring_cb._on_rollout_end()
+
+        logged = _merge_all_logs(mock_wandb)
+        assert "game/map_heatmap_table" in logged
+        table = logged["game/map_heatmap_table"]
+        assert set(table.columns) == {"map_id", "visit_count"}
+        assert any(row[0] == 1 for row in table.data)
+        assert any(row[0] == 2 for row in table.data)
+
+    def test_logs_flag_progress_for_all_18(self, monitoring_cb, mock_wandb):
+        self._populate(monitoring_cb)
+        monitoring_cb.num_timesteps = 2048
+        monitoring_cb._on_rollout_end()
+
+        logged = _merge_all_logs(mock_wandb)
+        assert "game/flag_progress" in logged
+        table = logged["game/flag_progress"]
+        assert len(table.data) == 18  # All pre-registered flags listed
+        assert "game/unique_flags_ever" in logged
+        assert logged["game/unique_flags_ever"] == 1
+
+    def test_logs_episode_breakdown(self, monitoring_cb, mock_wandb):
+        self._populate(monitoring_cb)
+        monitoring_cb.num_timesteps = 2048
+        monitoring_cb._on_rollout_end()
+
+        logged = _merge_all_logs(mock_wandb)
+        assert "game/episodes" in logged
+        table = logged["game/episodes"]
+        assert len(table.data) == 1
+        # Columns match expected order
+        expected_cols = {
+            "episode", "global_step", "reward", "length",
+            "maps_visited", "final_map", "badges",
+            "event_flags_triggered", "locations_visited",
+        }
+        assert expected_cols == set(table.columns)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Dashboard JSON snapshot
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestDashboardStateSnapshot:
+    def test_writes_snapshot_on_rollout_end(self, monitoring_cb):
+        monitoring_cb.locals = {"dones": [True], "infos": [_make_step_info()]}
+        monitoring_cb._on_step()
+        monitoring_cb.num_timesteps = 2048
+        monitoring_cb._on_rollout_end()
+
+        assert os.path.exists(monitoring_cb.dashboard_state_path)
+        with open(monitoring_cb.dashboard_state_path) as fh:
+            snapshot = json.load(fh)
+
+        assert snapshot["episode_count"] == 1
+        assert snapshot["num_timesteps"] == 2048
+        assert snapshot["map_visit_counts"]["1"] == 1
+        assert snapshot["flag_trigger_counts"]["EVENT_GOT_STARTER"] == 1
+        assert snapshot["flag_first_triggered"]["EVENT_GOT_STARTER"] == 1
+        assert len(snapshot["episodes"]) == 1
+
+    def test_snapshot_contains_all_18_flags(self, monitoring_cb):
+        monitoring_cb.num_timesteps = 100
+        monitoring_cb._on_rollout_end()
+
+        with open(monitoring_cb.dashboard_state_path) as fh:
+            snapshot = json.load(fh)
+
+        # Even before any episode, snapshot lists all 18 flags with count 0
+        assert len(snapshot["flag_trigger_counts"]) == 18
+        assert all(v == 0 for v in snapshot["flag_trigger_counts"].values())
+
+    def test_write_failure_is_silent(self, monitoring_cb, tmp_path):
+        # Point at a path that cannot be written (directory that doesn't
+        # exist and can't be created because the parent is a file)
+        monitoring_cb.dashboard_state_path = str(tmp_path / "not_a_dir" / "state.json")
+        monitoring_cb.num_timesteps = 100
+
+        # Pre-create a FILE at the parent so replace() fails on write
+        (tmp_path / "not_a_dir").write_text("I am not a dir")
+
+        # Should not raise
+        monitoring_cb._write_dashboard_state()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _merge_all_logs(mock_wandb) -> dict:
+    merged = {}
+    for call in mock_wandb.log.call_args_list:
+        merged.update(call.args[0])
+    return merged
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Add `MonitoringCallback` extending `WandbCallback` with four game-specific views:
  - **Map exploration heatmap** — cumulative map visit counts logged to W&B as both a Table and a matplotlib bar-chart image
  - **Event flag checklist** — all 18 pre-registered Boulder-Path flags from `pokemon_red_ai/game/event_flags.py`, including trigger count and first-triggered episode
  - **Periodic screen captures** — game screen logged as a W&B image every N episodes (configurable via `--screen-capture-freq`, default 10)
  - **Per-episode breakdown** — reward, length, maps_visited, final_map, badges, event_flags_triggered logged as a W&B Table row per episode
- Mirror all monitoring state to `<save_dir>/dashboard_state.json` on every rollout so local tools can read without a W&B account.
- Add `scripts/monitor.py` — a Streamlit dashboard that:
  - Auto-discovers runs under `--runs-dir`
  - Plots reward curves (with moving average) from `monitor.csv`
  - Shows map exploration grid + event flag checklist from `dashboard_state.json`
  - Supports side-by-side run comparison (overlay seeds)
  - Optionally overlays `rollout/ep_rew_mean` from TensorBoard if available
- Wire `MonitoringCallback` into `scripts/train.py` (replaces raw `WandbCallback` when W&B is enabled).
- Pass `info_keywords=MONITORED_INFO_KEYS` to the SB3 `Monitor` wrapper so custom per-step metrics (maps_visited, event_progress, badges_earned, …) propagate into `ep_info_buffer` — this was an existing gap that made a couple of keys in `WandbCallback` silently no-op at runtime.
- Add Streamlit as an optional dep (`pip install -e ".[dashboard]"`).

Answers the research question *"is this run worth continuing?"* by putting rising reward, new maps, and ticking event flags on one screen.

## Test plan
- [x] `tests/unit/training/test_monitoring_callback.py` — 14 tests covering per-episode recording, screen-capture schedule (including disable-at-0 path), map heatmap, flag progress (all 18 flags), episode breakdown, dashboard JSON snapshot (including write-failure tolerance)
- [x] `tests/unit/test_monitor_script.py` — 19 tests covering run discovery, `dashboard_state.json` + `monitor.csv` loaders, all DataFrame builders, run summary, CLI parser
- [x] Full suite still green: **631 passed** locally
- [ ] Launch `streamlit run scripts/monitor.py -- --runs-dir ./training_output` against a live run once reviewer merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)