### PR TITLE
Add reward breakdowns, level curves, W&B metric organization (AMC-76)

### DIFF
--- a/pokemon_red_ai/training/callbacks.py
+++ b/pokemon_red_ai/training/callbacks.py
@@ -922,6 +922,8 @@ MONITORED_INFO_KEYS: tuple = (
     "current_map",
     "unique_maps_list",
     "player_level",
+    "pokemon_count",
+    "money",
 )
 
 
@@ -991,7 +993,22 @@ class MonitoringCallback(WandbCallback):
         self._flag_first_triggered: Dict[str, int] = {}
         self._episode_rows: List[Dict[str, Any]] = []
 
+        # Per-step reward component accumulators (keyed by env index).
+        # Each value is a defaultdict(float) that accumulates per-step
+        # reward breakdown dicts over the course of an episode.  Reset
+        # when the episode ends.
+        self._reward_accumulators: Dict[int, Dict[str, float]] = {}
+
+        # Per-episode game-state histories for W&B charts
+        self._level_history: List[int] = []
+        self._pokemon_count_history: List[int] = []
+        self._money_history: List[int] = []
+        self._episode_reward_components: List[Dict[str, float]] = []
+
         os.makedirs(os.path.dirname(os.path.abspath(self.dashboard_state_path)), exist_ok=True)
+
+        # Define W&B metric grouping so panels auto-organise
+        self._define_wandb_metrics()
 
         if self.verbose >= 1:
             logger.info(
@@ -1001,20 +1018,57 @@ class MonitoringCallback(WandbCallback):
             )
 
     # ------------------------------------------------------------------
+    # W&B metric grouping
+    # ------------------------------------------------------------------
+
+    def _define_wandb_metrics(self) -> None:
+        """Set ``wandb.define_metric`` for automatic panel organisation.
+
+        Groups metrics under ``episode/``, ``game/``, and ``reward/``
+        sections so the W&B dashboard auto-creates useful panels without
+        manual configuration.  Failures are swallowed silently because
+        older wandb versions may not support ``define_metric``.
+        """
+        try:
+            w = self._wandb
+            w.define_metric("global_step")
+            # Episode scalars plotted against global_step
+            w.define_metric("episode/*", step_metric="global_step")
+            # Game-state metrics
+            w.define_metric("game/*", step_metric="global_step")
+            # Reward component breakdown
+            w.define_metric("reward/*", step_metric="global_step")
+        except Exception:
+            pass  # define_metric is best-effort
+
+    # ------------------------------------------------------------------
     # SB3 callback interface
     # ------------------------------------------------------------------
 
     def _on_step(self) -> bool:
-        """Detect episode endings and record per-episode stats."""
+        """Accumulate per-step reward components and record episodes."""
         dones = self.locals.get("dones")
         infos = self.locals.get("infos")
         if dones is None or infos is None:
             return True
 
-        for done, info in zip(dones, infos):
-            if not done:
-                continue
-            self._record_episode(info)
+        for env_idx, (done, info) in enumerate(zip(dones, infos)):
+            # Accumulate reward components every step (cheap dict adds)
+            components = info.get("reward_components")
+            if components and isinstance(components, dict):
+                if env_idx not in self._reward_accumulators:
+                    self._reward_accumulators[env_idx] = defaultdict(float)
+                for key, val in components.items():
+                    try:
+                        self._reward_accumulators[env_idx][key] += float(val)
+                    except (TypeError, ValueError):
+                        continue
+
+            if done:
+                # Snapshot the accumulated reward components for this
+                # episode, then clear the accumulator.
+                accumulated = dict(self._reward_accumulators.pop(env_idx, {}))
+                self._record_episode(info, reward_components=accumulated)
 
         return True
 
@@ -1033,7 +1087,11 @@ class MonitoringCallback(WandbCallback):
     # Episode recording
     # ------------------------------------------------------------------
 
-    def _record_episode(self, info: Dict[str, Any]) -> None:
+    def _record_episode(
+        self,
+        info: Dict[str, Any],
+        reward_components: Optional[Dict[str, float]] = None,
+    ) -> None:
         self._episode_count += 1
         self._episodes_since_screen += 1
 
@@ -1050,6 +1108,11 @@ class MonitoringCallback(WandbCallback):
         triggered_names = list(event_progress.get("triggered_names", []) or [])
         flags_triggered = int(event_progress.get("flags_triggered", len(triggered_names)))
 
+        # Game-state fields for level/money/party tracking
+        player_level = int(info.get("player_level", 0) or 0)
+        pokemon_count = int(info.get("pokemon_count", 0) or 0)
+        money = int(info.get("money", 0) or 0)
+
         # Update cumulative counts
         for map_id in unique_maps:
             try:
@@ -1060,6 +1123,13 @@ class MonitoringCallback(WandbCallback):
         for flag_name in triggered_names:
             self._flag_trigger_counts[flag_name] += 1
             self._flag_first_triggered.setdefault(flag_name, self._episode_count)
+
+        # Store game-state histories
+        self._level_history.append(player_level)
+        self._pokemon_count_history.append(pokemon_count)
+        self._money_history.append(money)
+        if reward_components:
+            self._episode_reward_components.append(reward_components)
 
         self._episode_rows.append(
             {
@@ -1073,6 +1143,10 @@ class MonitoringCallback(WandbCallback):
                 "event_flags_triggered": flags_triggered,
                 "locations_visited": locations,
                 "triggered_flags": triggered_names,
+                "player_level": player_level,
+                "pokemon_count": pokemon_count,
+                "money": money,
+                "reward_components": reward_components or {},
             }
         )
 
@@ -1135,7 +1209,7 @@ class MonitoringCallback(WandbCallback):
     # ------------------------------------------------------------------
 
     def _log_extras(self) -> None:
-        """Log heatmap, flag progress, and per-episode table to W&B."""
+        """Log heatmap, flag progress, reward breakdown, and more to W&B."""
         try:
             self._log_map_heatmap()
         except Exception as exc:
@@ -1150,6 +1224,16 @@ class MonitoringCallback(WandbCallback):
             self._log_episode_table()
         except Exception as exc:
             logger.debug(f"Episode table log failed: {exc}")
+
+        try:
+            self._log_reward_breakdown()
+        except Exception as exc:
+            logger.debug(f"Reward breakdown log failed: {exc}")
+
+        try:
+            self._log_game_state_metrics()
+        except Exception as exc:
+            logger.debug(f"Game state metrics log failed: {exc}")
 
     def _log_map_heatmap(self) -> None:
         if not self._map_visit_counts:
@@ -1240,6 +1324,9 @@ class MonitoringCallback(WandbCallback):
                 "badges",
                 "event_flags_triggered",
                 "locations_visited",
+                "player_level",
+                "pokemon_count",
+                "money",
             ]
         )
         for row in self._episode_rows[-500:]:  # cap to avoid huge payloads
@@ -1253,11 +1340,73 @@ class MonitoringCallback(WandbCallback):
                 row["badges"],
                 row["event_flags_triggered"],
                 row["locations_visited"],
+                row.get("player_level", 0),
+                row.get("pokemon_count", 0),
+                row.get("money", 0),
             )
         self._wandb.log(
             {"game/episodes": table},
             step=self.num_timesteps,
         )
+
+    # ------------------------------------------------------------------
+    # Reward breakdown & game-state logging
+    # ------------------------------------------------------------------
+
+    def _log_reward_breakdown(self) -> None:
+        """Log per-component reward scalars averaged over recent episodes.
+
+        Produces W&B scalar lines like ``reward/exploration``,
+        ``reward/badge``, ``reward/event_flags``, etc. that let
+        researchers see which components the agent is exploiting.
+        """
+        recent = self._episode_reward_components[-50:]
+        if not recent:
+            return
+
+        # Collect all component keys across recent episodes
+        all_keys: set = set()
+        for rc in recent:
+            all_keys.update(rc.keys())
+
+        metrics: Dict[str, Any] = {}
+        for key in sorted(all_keys):
+            values = [rc.get(key, 0.0) for rc in recent]
+            metrics[f"reward/{key}_mean"] = float(np.mean(values))
+            metrics[f"reward/{key}_max"] = float(np.max(values))
+
+        # Total reward from components (sanity check)
+        totals = [sum(rc.values()) for rc in recent]
+        metrics["reward/total_components_mean"] = float(np.mean(totals))
+
+        self._wandb.log(metrics, step=self.num_timesteps)
+
+    def _log_game_state_metrics(self) -> None:
+        """Log level curves, party size, and money as W&B scalars.
+
+        These provide the \"game progress\" view: is the agent levelling
+        up, catching Pokemon, and accumulating money over training?
+        """
+        metrics: Dict[str, Any] = {}
+
+        if self._level_history:
+            recent_levels = self._level_history[-50:]
+            metrics["game/player_level_mean"] = float(np.mean(recent_levels))
+            metrics["game/player_level_max"] = int(np.max(recent_levels))
+            metrics["game/player_level_latest"] = recent_levels[-1]
+
+        if self._pokemon_count_history:
+            recent_counts = self._pokemon_count_history[-50:]
+            metrics["game/pokemon_count_mean"] = float(np.mean(recent_counts))
+            metrics["game/pokemon_count_max"] = int(np.max(recent_counts))
+
+        if self._money_history:
+            recent_money = self._money_history[-50:]
+            metrics["game/money_mean"] = float(np.mean(recent_money))
+            metrics["game/money_max"] = int(np.max(recent_money))
+
+        if metrics:
+            self._wandb.log(metrics, step=self.num_timesteps)
 
     # ------------------------------------------------------------------
     # Dashboard JSON snapshot
@@ -1275,6 +1424,17 @@ class MonitoringCallback(WandbCallback):
             flag_names = list(BOULDER_PATH_FLAGS)
         except Exception:
             flag_names = list(self._flag_trigger_counts)
+
+        # Aggregate recent reward components for the dashboard
+        recent_rc = self._episode_reward_components[-50:]
+        rc_summary: Dict[str, float] = {}
+        if recent_rc:
+            all_keys: set = set()
+            for rc in recent_rc:
+                all_keys.update(rc.keys())
+            for key in sorted(all_keys):
+                vals = [rc.get(key, 0.0) for rc in recent_rc]
+                rc_summary[key] = float(np.mean(vals))
 
         snapshot = {
             "num_timesteps": int(self.num_timesteps),
@@ -1294,6 +1454,11 @@ class MonitoringCallback(WandbCallback):
                 for name in flag_names
             },
             "episodes": self._episode_rows[-200:],
+            # Enhanced metrics
+            "level_history": self._level_history[-200:],
+            "pokemon_count_history": self._pokemon_count_history[-200:],
+            "money_history": self._money_history[-200:],
+            "reward_component_summary": rc_summary,
         }
 
         try:

--- a/tests/unit/training/test_monitoring_callback.py
+++ b/tests/unit/training/test_monitoring_callback.py
@@ -106,8 +106,12 @@ def _make_step_info(
     current_map=2,
     badges=1,
     locations=42,
+    player_level=5,
+    pokemon_count=1,
+    money=3000,
+    reward_components=None,
 ):
-    return {
+    info = {
         "episode": {"r": reward, "l": length},
         "unique_maps_list": list(unique_maps),
         "event_progress": {
@@ -117,7 +121,13 @@ def _make_step_info(
         "current_map": current_map,
         "badges_earned": badges,
         "locations_visited": locations,
+        "player_level": player_level,
+        "pokemon_count": pokemon_count,
+        "money": money,
     }
+    if reward_components is not None:
+        info["reward_components"] = reward_components
+    return info
 
 
 class TestOnStepEpisodeTracking:
@@ -284,11 +294,12 @@ class TestRolloutEndExtras:
         assert "game/episodes" in logged
         table = logged["game/episodes"]
         assert len(table.data) == 1
-        # Columns match expected order
+        # Columns match expected order (including AMC-76 additions)
         expected_cols = {
             "episode", "global_step", "reward", "length",
             "maps_visited", "final_map", "badges",
             "event_flags_triggered", "locations_visited",
+            "player_level", "pokemon_count", "money",
         }
         assert expected_cols == set(table.columns)
 
@@ -338,6 +349,296 @@ class TestDashboardStateSnapshot:
 
         # Should not raise
         monitoring_cb._write_dashboard_state()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Reward component accumulation (AMC-76)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestRewardComponentAccumulation:
+    """Tests for per-step reward component tracking."""
+
+    def test_accumulates_across_steps(self, monitoring_cb):
+        """Components should sum over the episode, not just last step."""
+        # Step 1: non-terminal, has reward components
+        monitoring_cb.locals = {
+            "dones": [False],
+            "infos": [{"reward_components": {"exploration": 5.0, "time": -0.01}}],
+        }
+        monitoring_cb._on_step()
+
+        # Step 2: non-terminal
+        monitoring_cb.locals = {
+            "dones": [False],
+            "infos": [{"reward_components": {"exploration": 3.0, "time": -0.01}}],
+        }
+        monitoring_cb._on_step()
+
+        # Step 3: terminal — triggers _record_episode
+        monitoring_cb.locals = {
+            "dones": [True],
+            "infos": [_make_step_info(
+                reward_components={"exploration": 2.0, "time": -0.01, "badge": 150.0},
+            )],
+        }
+        monitoring_cb._on_step()
+
+        assert monitoring_cb._episode_count == 1
+        rc = monitoring_cb._episode_reward_components[0]
+        assert rc["exploration"] == pytest.approx(10.0)  # 5 + 3 + 2
+        assert rc["time"] == pytest.approx(-0.03)  # -0.01 * 3
+        assert rc["badge"] == pytest.approx(150.0)
+
+    def test_accumulator_resets_after_episode(self, monitoring_cb):
+        """Each episode gets its own accumulation, no bleed."""
+        # Episode 1
+        monitoring_cb.locals = {
+            "dones": [True],
+            "infos": [_make_step_info(
+                reward_components={"exploration": 5.0},
+            )],
+        }
+        monitoring_cb._on_step()
+
+        # Episode 2 (different components)
+        monitoring_cb.locals = {
+            "dones": [True],
+            "infos": [_make_step_info(
+                reward_components={"badge": 100.0},
+            )],
+        }
+        monitoring_cb._on_step()
+
+        assert len(monitoring_cb._episode_reward_components) == 2
+        assert monitoring_cb._episode_reward_components[0] == {"exploration": 5.0}
+        assert monitoring_cb._episode_reward_components[1] == {"badge": 100.0}
+
+    def test_handles_missing_components_gracefully(self, monitoring_cb):
+        """Steps without reward_components should not crash."""
+        monitoring_cb.locals = {
+            "dones": [True],
+            "infos": [_make_step_info()],  # no reward_components
+        }
+        monitoring_cb._on_step()
+        assert monitoring_cb._episode_count == 1
+        # No components recorded, but episode still logged
+        row = monitoring_cb._episode_rows[0]
+        assert row["reward_components"] == {}
+
+    def test_multi_env_isolation(self, monitoring_cb):
+        """Accumulators for different envs stay separate."""
+        # Both envs step, only env 0 terminates
+        monitoring_cb.locals = {
+            "dones": [True, False],
+            "infos": [
+                _make_step_info(reward_components={"exploration": 5.0}),
+                {"reward_components": {"exploration": 99.0}},
+            ],
+        }
+        monitoring_cb._on_step()
+
+        # Env 0's episode should NOT include env 1's components
+        assert monitoring_cb._episode_count == 1
+        rc = monitoring_cb._episode_reward_components[0]
+        assert rc["exploration"] == pytest.approx(5.0)
+
+        # Env 1's accumulator should still be active
+        assert 1 in monitoring_cb._reward_accumulators
+        assert monitoring_cb._reward_accumulators[1]["exploration"] == pytest.approx(99.0)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Game state metrics (AMC-76)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestGameStateMetrics:
+    """Tests for level, money, and pokemon count tracking."""
+
+    def test_records_player_level(self, monitoring_cb):
+        monitoring_cb.locals = {
+            "dones": [True],
+            "infos": [_make_step_info(player_level=7)],
+        }
+        monitoring_cb._on_step()
+
+        assert monitoring_cb._level_history == [7]
+        row = monitoring_cb._episode_rows[0]
+        assert row["player_level"] == 7
+
+    def test_records_pokemon_count(self, monitoring_cb):
+        monitoring_cb.locals = {
+            "dones": [True],
+            "infos": [_make_step_info(pokemon_count=3)],
+        }
+        monitoring_cb._on_step()
+
+        assert monitoring_cb._pokemon_count_history == [3]
+        row = monitoring_cb._episode_rows[0]
+        assert row["pokemon_count"] == 3
+
+    def test_records_money(self, monitoring_cb):
+        monitoring_cb.locals = {
+            "dones": [True],
+            "infos": [_make_step_info(money=5000)],
+        }
+        monitoring_cb._on_step()
+
+        assert monitoring_cb._money_history == [5000]
+
+    def test_logs_level_curves_to_wandb(self, monitoring_cb, mock_wandb):
+        # Populate multiple episodes with increasing levels
+        for level in [5, 6, 7, 8]:
+            monitoring_cb.locals = {
+                "dones": [True],
+                "infos": [_make_step_info(player_level=level)],
+            }
+            monitoring_cb._on_step()
+
+        monitoring_cb.num_timesteps = 4096
+        monitoring_cb._on_rollout_end()
+
+        logged = _merge_all_logs(mock_wandb)
+        assert "game/player_level_mean" in logged
+        assert "game/player_level_max" in logged
+        assert logged["game/player_level_max"] == 8
+        assert logged["game/player_level_mean"] == pytest.approx(6.5)
+
+    def test_logs_reward_breakdown_to_wandb(self, monitoring_cb, mock_wandb):
+        monitoring_cb.locals = {
+            "dones": [True],
+            "infos": [_make_step_info(
+                reward_components={"exploration": 10.0, "time": -0.5, "badge": 150.0},
+            )],
+        }
+        monitoring_cb._on_step()
+
+        monitoring_cb.num_timesteps = 2048
+        monitoring_cb._on_rollout_end()
+
+        logged = _merge_all_logs(mock_wandb)
+        assert "reward/exploration_mean" in logged
+        assert "reward/badge_mean" in logged
+        assert "reward/time_mean" in logged
+        assert "reward/total_components_mean" in logged
+        assert logged["reward/badge_mean"] == pytest.approx(150.0)
+
+    def test_missing_game_state_uses_defaults(self, monitoring_cb):
+        """Info dict without level/money/count should use 0."""
+        monitoring_cb.locals = {
+            "dones": [True],
+            "infos": [{"episode": {"r": 1.0, "l": 10}}],
+        }
+        monitoring_cb._on_step()
+
+        row = monitoring_cb._episode_rows[0]
+        assert row["player_level"] == 0
+        assert row["pokemon_count"] == 0
+        assert row["money"] == 0
+
+
+# ──────────────────────────────────────────────────────────────────────
+# W&B define_metric (AMC-76)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestWandbMetricDefinition:
+    """Tests for W&B panel organisation."""
+
+    def test_define_metric_called_on_init(self, mock_wandb, tmp_path):
+        with patch.dict("sys.modules", {"wandb": mock_wandb}):
+            cb = MonitoringCallback(
+                save_path=str(tmp_path),
+                verbose=0,
+            )
+
+        mock_wandb.define_metric.assert_called()
+        calls = [str(c) for c in mock_wandb.define_metric.call_args_list]
+        # Should have calls for global_step, episode/*, game/*, reward/*
+        assert any("global_step" in c for c in calls)
+        assert any("episode/*" in c for c in calls)
+        assert any("game/*" in c for c in calls)
+        assert any("reward/*" in c for c in calls)
+
+    def test_define_metric_failure_is_silent(self, mock_wandb, tmp_path):
+        mock_wandb.define_metric.side_effect = AttributeError("old wandb")
+        with patch.dict("sys.modules", {"wandb": mock_wandb}):
+            # Should not raise
+            cb = MonitoringCallback(
+                save_path=str(tmp_path),
+                verbose=0,
+            )
+        assert cb is not None
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Enhanced dashboard snapshot (AMC-76)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestEnhancedDashboardSnapshot:
+    """Tests for enhanced dashboard JSON state."""
+
+    def test_snapshot_includes_level_history(self, monitoring_cb):
+        monitoring_cb.locals = {
+            "dones": [True],
+            "infos": [_make_step_info(player_level=8)],
+        }
+        monitoring_cb._on_step()
+        monitoring_cb.num_timesteps = 100
+        monitoring_cb._on_rollout_end()
+
+        with open(monitoring_cb.dashboard_state_path) as fh:
+            snapshot = json.load(fh)
+
+        assert "level_history" in snapshot
+        assert snapshot["level_history"] == [8]
+
+    def test_snapshot_includes_reward_summary(self, monitoring_cb):
+        monitoring_cb.locals = {
+            "dones": [True],
+            "infos": [_make_step_info(
+                reward_components={"exploration": 10.0, "badge": 150.0},
+            )],
+        }
+        monitoring_cb._on_step()
+        monitoring_cb.num_timesteps = 100
+        monitoring_cb._on_rollout_end()
+
+        with open(monitoring_cb.dashboard_state_path) as fh:
+            snapshot = json.load(fh)
+
+        assert "reward_component_summary" in snapshot
+        assert snapshot["reward_component_summary"]["exploration"] == pytest.approx(10.0)
+        assert snapshot["reward_component_summary"]["badge"] == pytest.approx(150.0)
+
+    def test_snapshot_includes_money_history(self, monitoring_cb):
+        monitoring_cb.locals = {
+            "dones": [True],
+            "infos": [_make_step_info(money=5000)],
+        }
+        monitoring_cb._on_step()
+        monitoring_cb.num_timesteps = 100
+        monitoring_cb._on_rollout_end()
+
+        with open(monitoring_cb.dashboard_state_path) as fh:
+            snapshot = json.load(fh)
+
+        assert "money_history" in snapshot
+        assert snapshot["money_history"] == [5000]
+        assert "pokemon_count_history" in snapshot
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Info keys contract (AMC-76 additions)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_monitored_info_keys_include_new_fields():
+    """AMC-76 added pokemon_count and money to MONITORED_INFO_KEYS."""
+    assert "pokemon_count" in MONITORED_INFO_KEYS
+    assert "money" in MONITORED_INFO_KEYS
 
 
 # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Enhances `MonitoringCallback` with three capabilities the observability stack was missing:
  - **Reward component breakdowns**: Accumulates `reward_components` on every env step (not just episode end) and logs `reward/exploration_mean`, `reward/badge_mean`, `reward/time_mean`, etc. as W&B scalars. Researchers can now see which reward signals the agent is exploiting over training.
  - **Game-state level/money/party curves**: Records `player_level`, `pokemon_count`, and `money` at episode boundaries. Logs `game/player_level_mean`, `game/player_level_max`, `game/player_level_latest`, plus pokemon count and money curves.
  - **W&B `define_metric()` organization**: Groups panels under `episode/*`, `game/*`, and `reward/*` with `global_step` as the x-axis so the W&B dashboard auto-creates structured panel groups.
- Extends the episode table with 3 new columns: `player_level`, `pokemon_count`, `money`
- Extends `dashboard_state.json` with `level_history`, `money_history`, `pokemon_count_history`, and `reward_component_summary`
- Adds `pokemon_count` and `money` to `MONITORED_INFO_KEYS`
- Multi-env safe: reward accumulators are keyed by env index and reset per-episode

## W&B Dashboard After This PR
When you run training, the W&B dashboard will auto-organize into:
- **episode/** — reward_mean, reward_max, length_mean, best_reward
- **game/** — maps_visited, badges, event_flags, player_level, pokemon_count, money, screen captures
- **reward/** — per-component breakdown (exploration, badge, time, death, event_flags, etc.)

## Test plan
- [x] 16 new tests added (30 total in `test_monitoring_callback.py`)
- [x] All 696 project tests pass
- [x] Verified reward accumulation across steps, accumulator reset between episodes, multi-env isolation
- [x] Verified graceful handling of missing fields and old wandb versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)